### PR TITLE
Does a buffer size check before adding to the buffer

### DIFF
--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -129,10 +129,10 @@ class Emitter(object):
             :param payload:   The name-value pairs for the event
             :type  payload:   dict(string:*)
         """
-        self.buffer.append(payload)
-
         if len(self.buffer) >= self.buffer_size:
             return self.flush()
+
+        self.buffer.append(payload)
 
     @task(name="Flush")
     def flush(self):


### PR DESCRIPTION
If the buffer is already at `buffer_size` then appending to it would be `buffer_size+1`. So the newly created event would then go out in the next `flush()`.

It really doesn't matter that much in the big picture, but at least we know that we're always within our own defined limit.
