### PR TITLE
Add FileWorker based off RedisWorker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pycontracts==1.6.0
+pygtail==0.6.0
 requests==2.2.1
 celery==3.1.11
 gevent==1.0.0

--- a/snowplow_tracker/file_worker.py
+++ b/snowplow_tracker/file_worker.py
@@ -1,0 +1,42 @@
+"""
+    file_worker.py
+"""
+
+from pygtail import Pygtail
+import json
+import signal
+
+class FileWorker(object):
+    """
+        Synchronously read events from file and send them to an emitter
+    """
+
+    def __init__(self, emitter, filename):
+        self.emitter = emitter
+        self.pygtail = Pygtail(filename, paranoid=True)
+
+        signal.signal(signal.SIGTERM, self.request_shutdown)
+        signal.signal(signal.SIGINT, self.request_shutdown)
+        signal.signal(signal.SIGQUIT, self.request_shutdown)
+
+    def send(self, payload):
+        """
+            Send an event to an emitter
+        """
+        self.emitter.input(payload)
+
+    def run(self):
+        """
+            Run indefinitely
+        """
+        self._shutdown = False
+
+        while not self._shutdown:
+            payload = self.pygtail.next()
+            self.send(json.loads(payload.decode("utf-8")))
+
+    def request_shutdown(self, *args):
+        """
+            Halt the worker
+        """
+        self._shutdown = True


### PR DESCRIPTION
I thought it would be useful to have a `FileWorker` similar to `RedisWorker`, that could simply read JSON snowplow events written to a file, and send them to an emitter.

This might also pair well with a `FileEmitter`.

Wanted to get some thoughts if others would find this useful and be willing to include it.
