### PR TITLE
Add missing dependencies to .travis.yml and setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
   - "pip install httmock"
   - "pip install freezegun"
   - "pip install coveralls"
+  - "pip install ."
   - "python setup.py install"
 # command to run tests
 script:

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "pycontracts",
         "celery",
         "gevent",
-        "redis"
+        "redis",
+        "six"
     ],
 )


### PR DESCRIPTION
Travis builds are failing because the standard dependencies are not installed.
Add explicit `pip install .` to `.travis.yml`.

`setup.py` does not include `six` as a dependency, which is in `requirements.txt` and is directly imported by `tracker.py`.
Add `six` to `install_requires` in `setup.py`.