### PR TITLE
Drop Python 3.2 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
 # command to install dependencies
 install:


### PR DESCRIPTION
Remove Python 3.2 from .travis.yml.
Add classifiers for Python 2.7 and 3.2 to setup.py