### PR TITLE
Do not pin dependencies to specific versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 - '3.4'
 - '3.5'
 install:
+# ensure we have recent pip/setuptools
+- pip install --upgrade pip setuptools
 - pip install -r requirements-test.txt
 - pip install release-manager
 - pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -75,12 +75,12 @@ setup(
     ],
 
     install_requires=[
-        "greenlet==0.4.10",
-        "requests==2.2.1",
+        "greenlet>=0.4.10",
+        "requests>=2.2.1",
         "pycontracts==1.7.6",
-        "celery==3.1.11",
-        "gevent==1.0.2",
-        "redis==2.9.1",
-        "six==1.9.0"
+        "celery>=3.1.11,<3.1.25",
+        "gevent>=1.0.2",
+        "redis>=2.9.1",
+        "six>=1.9.0"
     ],
 )


### PR DESCRIPTION
Because the packages in `setup.py` are really old and they use exact
version, when installing the package into a virtualenv it will end-up
downgrading already existing  packages.

In the Python documentation it is also mentioned that it is not a best
practice to use `install_requires` to pin dependencies to specific versions.

See also:

- https://github.com/snowplow/snowplow-python-tracker/issues/195
- https://github.com/snowplow/snowplow-python-tracker/issues/198
- https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires