### PR TITLE
Update gevent version to support python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "requests==2.2.1",
         "pycontracts==1.7.6",
         "celery==3.1.11",
-        "gevent==1.0.2",
+        "gevent==1.1.0",
         "redis==2.9.1",
         "six==1.9.0"
     ],

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -30,6 +30,7 @@ except ImportError:
     # Python 3
     from queue import Queue
 
+import celery
 from celery import Celery
 from celery.contrib.methods import task
 import redis
@@ -51,16 +52,6 @@ new_contract("method", lambda x: x == "get" or x == "post")
 new_contract("function", lambda x: hasattr(x, "__call__"))
 
 new_contract("redis", lambda x: isinstance(x, (redis.Redis, redis.StrictRedis)))
-
-try:
-    # Check whether a custom Celery configuration module named "snowplow_celery_config" exists
-    import snowplow_celery_config
-    app = Celery()
-    app.config_from_object(snowplow_celery_config)
-
-except ImportError:
-    # Otherwise configure Celery with default settings
-    app = Celery("Snowplow", broker="redis://guest@localhost//")
 
 
 class Emitter(object):
@@ -394,6 +385,16 @@ class CeleryEmitter(Emitter):
         but on_success and on_failure callbacks cannot be set.
     """
     def __init__(self, endpoint, protocol="http", port=None, method="get", buffer_size=None, byte_limit=None):
+        if not celery.current_app or not celery.current_app.configured:
+            try:
+                # Check whether a custom Celery configuration module named "snowplow_celery_config" exists
+                import snowplow_celery_config
+                app = Celery()
+                app.config_from_object(snowplow_celery_config)
+
+            except ImportError:
+                # Otherwise configure Celery with default settings
+                app = Celery("Snowplow", broker="redis://guest@localhost//")
         super(CeleryEmitter, self).__init__(endpoint, protocol, port, method, buffer_size, None, None, byte_limit)
 
     def flush(self):


### PR DESCRIPTION
gevent version 1.0.2 doesn't support python 3. Version 1.1.0 is the first to support python versions >= 3.3 (https://pypi.org/project/gevent/1.1.0/)