### PR TITLE
Release/0.8.4

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,27 @@
+name: Snyk
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: snyk/actions/setup@master
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    
+    - name: Run Snyk to check for vulnerabilities
+      run: snyk monitor --file=setup.py --project-name=snowplow-python-tracker
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: python
+dist: xenial
 services:
+  - redis
   - redis-server
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
-matrix:
-  include:
-    - python: '3.7'
-      dist: xenial
-      sudo: true
+  - '3.6'
+  - '3.7'
+  - '3.8'
+  - '3.9-dev'
 install:
   - pip install -U pip setuptools virtualenv twine
   - pip install -r requirements-test.txt

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+Version 0.8.4 (2020-10-10)
+--------------------------
+Fix incompatible versions of greenlet and gevent (closes #236)
+Update build to Active Python Releases (closes #237)
+Add Snyk monitoring (closes #238)
+Update Copyright notices to 2020 (closes #235)
+
 Version 0.8.3 (2019-06-28)
 --------------------------
 Fix test_bytelimit test (#227)

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Assuming pyenv_ is installed
 
    host$ git clone git@github.com:snowplow/snowplow-python-tracker.git
    host$ cd snowplow-python-tracker
-   host$ pyenv install 2.7.15 && pyenv install 3.4.9 && pyenv install 3.5.2 && pyenv install 3.7.1
+   host$ pyenv install 2.7.18 && pyenv install 3.5.10 && pyenv install 3.6.12 && pyenv install 3.7.9 && pyenv install 3.8.6 && pyenv install 3.9.0
    host$ ./run-tests.sh deploy
    host$ ./run-tests.sh test
 

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Assuming pyenv_ is installed
 Copyright and license
 #####################
 
-The Snowplow Python Tracker is copyright 2013-2019 Snowplow Analytics Ltd.
+The Snowplow Python Tracker is copyright 2013-2020 Snowplow Analytics Ltd.
 
 Licensed under the `Apache License, Version 2.0`_ (the "License");
 you may not use this software except in compliance with the License.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
-pytest==4.0.1
-httmock==1.2.5
-freezegun==0.3.11
-pytest-cov==2.6.0
-coveralls==1.5.1
+pytest==4.6.11
+attrs==19.1.0
+httmock==1.3.0
+freezegun==0.3.15
+pytest-cov==2.10.1
+coveralls==1.11.1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -17,35 +17,53 @@ eval "$(pyenv virtualenv-init -)"
 function deploy {
   # pyenv install 2.7.15
   if [ ! -f ~/.pyenv/versions/tracker27 ]; then
-    pyenv virtualenv 2.7.15 tracker27
+    pyenv virtualenv 2.7.18 tracker27
     pyenv activate tracker27
     pip install .
     pip install -r requirements-test.txt
     source deactivate
   fi
 
-  # pyenv install 3.4.9
-  if [ ! -f ~/.pyenv/versions/tracker34 ]; then
-    pyenv virtualenv 3.4.9 tracker34
-    pyenv activate tracker34
-    pip install .
-    pip install -r requirements-test.txt
-    source deactivate
-  fi
-
-  # pyenv install 3.5.2
+  # pyenv install 3.5.10
   if [ ! -f ~/.pyenv/versions/tracker35 ]; then
-    pyenv virtualenv 3.5.2 tracker35
+    pyenv virtualenv 3.5.10 tracker35
     pyenv activate tracker35
     pip install .
     pip install -r requirements-test.txt
     source deactivate
   fi
 
-  # pyenv install 3.7.1
+  # pyenv install 3.6.12
+  if [ ! -f ~/.pyenv/versions/tracker36 ]; then
+    pyenv virtualenv 3.6.12 tracker36
+    pyenv activate tracker36
+    pip install .
+    pip install -r requirements-test.txt
+    source deactivate
+  fi
+
+  # pyenv install 3.7.9
   if [ ! -f ~/.pyenv/versions/tracker37 ]; then
-    pyenv virtualenv 3.7.1 tracker37
+    pyenv virtualenv 3.7.9 tracker37
     pyenv activate tracker37
+    pip install .
+    pip install -r requirements-test.txt
+    source deactivate
+  fi
+
+  # pyenv install 3.8.6
+  if [ ! -f ~/.pyenv/versions/tracker38 ]; then
+    pyenv virtualenv 3.8.6 tracker38
+    pyenv activate tracker38
+    pip install .
+    pip install -r requirements-test.txt
+    source deactivate
+  fi
+
+  # pyenv install 3.9.0
+  if [ ! -f ~/.pyenv/versions/tracker39 ]; then
+    pyenv virtualenv 3.9.0 tracker39
+    pyenv activate tracker39
     pip install .
     pip install -r requirements-test.txt
     source deactivate
@@ -58,24 +76,34 @@ function run_tests {
   pytest -s
   source deactivate
   
-  pyenv activate tracker34
+  pyenv activate tracker35
   pytest
   source deactivate
-  
-  pyenv activate tracker35
+
+  pyenv activate tracker36
   pytest
   source deactivate
 
   pyenv activate tracker37
   pytest
-  source deactivate 
+  source deactivate
+
+  pyenv activate tracker38
+  pytest
+  source deactivate
+
+  pyenv activate tracker39
+  pytest
+  source deactivate
 }
 
 function refresh_deploy {
   pyenv uninstall -f tracker27
-  pyenv uninstall -f tracker34
   pyenv uninstall -f tracker35
+  pyenv uninstall -f tracker36
   pyenv uninstall -f tracker37
+  pyenv uninstall -f tracker38
+  pyenv uninstall -f tracker39
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
@@ -33,7 +33,8 @@ import os
 authors_list = [
     'Anuj More',
     'Alexander Dean',
-    'Fred Blundun'
+    'Fred Blundun',
+    'Paul Boocock'
     ]
 authors_str = ', '.join(authors_list)
 
@@ -44,7 +45,7 @@ authors_email_str = ', '.join(authors_email_list)
 
 setup(
     name='snowplow-tracker',
-    version='0.8.3',
+    version='0.8.4',
     author=authors_str,
     author_email=authors_email_str,
     packages=['snowplow_tracker', 'snowplow_tracker.test'],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """
     setup.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,11 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -30,13 +30,6 @@ except ImportError:
 
 import os
 
-version_file_path = os.path.join(
-    os.path.dirname(__file__),
-    'snowplow_tracker',
-    '_version.py'
-    )
-exec(open(version_file_path).read(), {}, locals())
-
 authors_list = [
     'Anuj More',
     'Alexander Dean',
@@ -51,7 +44,7 @@ authors_email_str = ', '.join(authors_email_list)
 
 setup(
     name='snowplow-tracker',
-    version=__version__,
+    version='0.8.3',
     author=authors_str,
     author_email=authors_email_str,
     packages=['snowplow_tracker', 'snowplow_tracker.test'],

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     ],
 
     install_requires=[
-        "greenlet>=0.4.10,<1.0",
+        "greenlet>=0.4.10,<=0.4.16",
         "requests>=2.2.1,<3.0",
         "pycontracts>=1.7.6,<2.0",
         "celery>=4.0,<5.0",

--- a/snowplow_tracker/_version.py
+++ b/snowplow_tracker/_version.py
@@ -14,12 +14,12 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 
 
-__version_info__ = (0, 8, 3)
+__version_info__ = (0, 8, 4)
 __version__ = ".".join(str(x) for x in __version_info__)
 __build_version__ = __version__ + ''

--- a/snowplow_tracker/_version.py
+++ b/snowplow_tracker/_version.py
@@ -1,7 +1,7 @@
 """
     _version.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -1,7 +1,7 @@
 """
     emitters.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/payload.py
+++ b/snowplow_tracker/payload.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/payload.py
+++ b/snowplow_tracker/payload.py
@@ -1,7 +1,7 @@
 """
     payload.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/redis_worker.py
+++ b/snowplow_tracker/redis_worker.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/redis_worker.py
+++ b/snowplow_tracker/redis_worker.py
@@ -1,7 +1,7 @@
 """
     redis_worker.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/self_describing_json.py
+++ b/snowplow_tracker/self_describing_json.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/self_describing_json.py
+++ b/snowplow_tracker/self_describing_json.py
@@ -1,7 +1,7 @@
 """
     self_describing_json.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/subject.py
+++ b/snowplow_tracker/subject.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/subject.py
+++ b/snowplow_tracker/subject.py
@@ -1,7 +1,7 @@
 """
     subject.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -1,7 +1,7 @@
 """
     test_integration.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/test/unit/test_payload.py
+++ b/snowplow_tracker/test/unit/test_payload.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/test/unit/test_payload.py
+++ b/snowplow_tracker/test/unit/test_payload.py
@@ -1,7 +1,7 @@
 """
     test_payload.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -1,7 +1,7 @@
 """
     test_tracker.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/timestamp.py
+++ b/snowplow_tracker/timestamp.py
@@ -1,7 +1,7 @@
 """
     self_describing_json.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun, Anton Parkhomenko
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 

--- a/snowplow_tracker/timestamp.py
+++ b/snowplow_tracker/timestamp.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun, Anton Parkhomenko
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock, Anton Parkhomenko
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -14,7 +14,7 @@
     express or implied. See the Apache License Version 2.0 for the specific
     language governing permissions and limitations there under.
 
-    Authors: Anuj More, Alex Dean, Fred Blundun
+    Authors: Anuj More, Alex Dean, Fred Blundun, Paul Boocock
     Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -1,7 +1,7 @@
 """
     tracker.py
 
-    Copyright (c) 2013-2019 Snowplow Analytics Ltd. All rights reserved.
+    Copyright (c) 2013-2020 Snowplow Analytics Ltd. All rights reserved.
 
     This program is licensed to you under the Apache License Version 2.0,
     and you may not use this file except in compliance with the Apache License
@@ -15,7 +15,7 @@
     language governing permissions and limitations there under.
 
     Authors: Anuj More, Alex Dean, Fred Blundun
-    Copyright: Copyright (c) 2013-2019 Snowplow Analytics Ltd
+    Copyright: Copyright (c) 2013-2020 Snowplow Analytics Ltd
     License: Apache License Version 2.0
 """
 


### PR DESCRIPTION
Patch release before 0.9.0 which pins `greenlet` to `<=0.4.16` to fix the issue with `0.4.17` breaking `gevent`.

Also bumps travis builds to run against latest active python versions (`3.9` isn't available on travis yet so using `3.9-dev`). Will switch to GitHub Actions for 0.9.0.

Also adds Snyk monitoring and updates copyright notices.