### PR TITLE
feat(payload): allow custom json encoder to be passed when configuring tracker

### DIFF
--- a/snowplow_tracker/payload.py
+++ b/snowplow_tracker/payload.py
@@ -63,7 +63,7 @@ class Payload:
             self.add(f, dict_[f])
 
     @contract
-    def add_json(self, dict_, encode_base64, type_when_encoded, type_when_not_encoded):
+    def add_json(self, dict_, encode_base64, type_when_encoded, type_when_not_encoded, json_encoder=None):
         """
             Add an encoded or unencoded JSON to the payload
 
@@ -75,17 +75,19 @@ class Payload:
             :type   type_when_encoded:      string
             :param  type_when_not_encoded:  Name of the field when encode_base64 is not set
             :type   type_when_not_encoded:  string
+            :param json_encoder:            Custom JSON serializer that gets called on non-serializable object
+            :type  json_encoder:            function | None
         """
 
         if dict_ is not None and dict_ != {}:
 
-            json_dict = json.dumps(dict_, ensure_ascii=False)
+            json_dict = json.dumps(dict_, ensure_ascii=False, default=json_encoder)
 
             if encode_base64:
                 encoded_dict = base64.urlsafe_b64encode(json_dict.encode("utf-8"))
                 if not isinstance(encoded_dict, str):
                     encoded_dict = encoded_dict.decode("utf-8")
-                self.add(type_when_encoded, encoded_dict)                
+                self.add(type_when_encoded, encoded_dict)
 
             else:
                 self.add(type_when_not_encoded, json_dict)

--- a/snowplow_tracker/test/unit/test_payload.py
+++ b/snowplow_tracker/test/unit/test_payload.py
@@ -40,6 +40,17 @@ def is_subset(dict1, dict2):
         return False
 
 
+def date_encoder(o):
+    """Sample custom JSON encoder which converts dates into their ISO format"""
+    from datetime import date
+    from json.encoder import JSONEncoder
+
+    if isinstance(o,date):
+        return o.isoformat()
+
+    return JSONEncoder.default(o)
+
+
 class TestPayload(unittest.TestCase):
 
     def setUp(self):
@@ -66,3 +77,16 @@ class TestPayload(unittest.TestCase):
         p.add_dict({"name4": 4, "name3": 3})            # Order doesn't matter
         output = {"n1": "v1", "n2": "v2", "name3": 3, "name4": 4}
         self.assertTrue(is_subset(output, p.nv_pairs))
+
+    def test_add_json_with_custom_enc(self):
+        from datetime import date
+        import json
+
+        p = payload.Payload()
+
+        input = {"key1": date(2020,2,1)}
+
+        p.add_json(input, False, "name1", "name1", date_encoder)
+
+        results = json.loads(p.nv_pairs["name1"])
+        self.assertTrue(is_subset({"key1": "2020-02-01"}, results))


### PR DESCRIPTION
It's a relatively common use-case for event payload data to not inherently be JSON serializable, notably when trying to capture things like timestamps, ORM models, or when using a [data parsing library](https://pydantic-docs.helpmanual.io/).

This augments `payload.add_json` to allow passing of a custom serializer to use when converting json values to JSON, and also adds it as an optional configuration parameter of the `Tracker` class. This change is non-breaking for current users, and will default to current existing behaviour (no custom encoder).

The idea is that consumers could then pass a custom serializer when initializing their tracker, and have it handle parsing those events before emitting them. I made a very barebones example encoder in the spec file for testing reasons, but a more well-known/used example of a json serializer function can be found here: https://github.com/samuelcolvin/pydantic/blob/master/pydantic/json.py#L77

Also see the library documentation for more information on usage: https://docs.python.org/3/library/json.html#json.JSONEncoder.default

Please let me know if you have any further questions :) 

