### PR TITLE
Add Demo App (Close #279)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - issue/279-add_demo_app
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - issue/279-add_demo_app
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Demo
       run: |
         cd examples
-        python app.py
+        python app.py "localhost:9090"
 
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
     - name: Tests
       run: |
         pytest --cov=snowplow_tracker --cov-report=xml
+      
+    - name: Demo
+      run: |
+        cd examples
+        python app.py
 
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop

--- a/examples/app.py
+++ b/examples/app.py
@@ -1,0 +1,30 @@
+from distutils.log import error
+from snowplow_tracker import Tracker, Emitter, Subject
+import sys
+
+
+def get_url_from_args():
+    if len(sys.argv) != 2:
+        raise ValueError("Collector Endpoint is required")
+    return sys.argv[1]
+
+
+def main():
+    collector_url = get_url_from_args()
+
+    e = Emitter(collector_url)
+
+    s = Subject().set_platform("pc")
+    s.set_lang("en").set_user_id("test_user")
+
+    t = Tracker(e, s)
+
+    print("Sending events to " + collector_url)
+
+    t.track_page_view("https://www.snowplowanalytics.com", "Homepage")
+    t.track_page_ping("https://www.snowplowanalytics.com", "Homepage")
+    t.track_link_click("https://www.snowplowanalytics.com")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/app.py
+++ b/examples/app.py
@@ -1,5 +1,5 @@
 from distutils.log import error
-from snowplow_tracker import Tracker, Emitter, Subject
+from snowplow_tracker import Tracker, Emitter, Subject, SelfDescribingJson
 import sys
 
 
@@ -25,6 +25,14 @@ def main():
     t.track_page_ping("https://www.snowplowanalytics.com", "Homepage")
     t.track_link_click("https://www.snowplowanalytics.com")
 
+    t.track_self_describing_event(
+        SelfDescribingJson(
+            "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
+            {"targetUrl": "example.com"},
+        )
+    )
+    t.track_struct_event("shop", "add-to-basket", None, "pcs", 2)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,1 @@
+snowplow-tracker==0.10.0

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,1 +1,0 @@
-snowplow-tracker==0.10.0


### PR DESCRIPTION
For issue 279

A demo app that checks the tracker API is still working. The app is run as part of the CI gh-action.

