### PR TITLE
Add missing Snowplow cookie attributes to the Subject class (close #282)

### DIFF
--- a/snowplow_tracker/subject.py
+++ b/snowplow_tracker/subject.py
@@ -123,6 +123,26 @@ class Subject(object):
         self.standard_nv_pairs["duid"] = duid
         return self
 
+    def set_domain_session_id(self, sid: str) -> 'Subject':
+        """
+            Set the domain session ID
+            :param sid:             Domain session ID
+            :type  sid:             string
+            :rtype:                 subject
+        """
+        self.standard_nv_pairs["sid"] = sid
+        return self
+
+    def set_domain_session_index(self, vid: int) -> 'Subject':
+        """
+            Set the domain session Index
+            :param vid:             Domain session Index
+            :type vid:              int
+            :rtype:                 subject
+        """
+        self.standard_nv_pairs["vid"] = vid
+        return self
+
     def set_ip_address(self, ip: str) -> 'Subject':
         """
             Set the domain user ID

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -226,6 +226,8 @@ class IntegrationTest(unittest.TestCase):
     def test_integration_identification_methods(self) -> None:
         s = subject.Subject()
         s.set_domain_user_id("4616bfb38f872d16")
+        s.set_domain_session_id("59ed13b1a5724dae")
+        s.set_domain_session_index(1)
         s.set_ip_address("255.255.255.255")
         s.set_useragent("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.0; Trident/5.0)")
         s.set_network_user_id("fbc6c76c-bce5-43ce-8d5a-31c5")
@@ -235,6 +237,8 @@ class IntegrationTest(unittest.TestCase):
             t.track_page_view("localhost", "local host")
         expected_fields = {
             "duid": "4616bfb38f872d16",
+            "sid": "59ed13b1a5724dae",
+            "vid": "1",
             "ip": "255.255.255.255",
             "ua": "Mozilla%2F5.0+%28compatible%3B+MSIE+9.0%3B+Windows+NT+6.0%3B+Trident%2F5.0%29",
             "tnuid": "fbc6c76c-bce5-43ce-8d5a-31c5"
@@ -245,7 +249,7 @@ class IntegrationTest(unittest.TestCase):
     def test_integration_event_subject(self) -> None:
         s = subject.Subject()
         s.set_domain_user_id("4616bfb38f872d16")
-        s.set_ip_address("255.255.255.255")
+        s.set_lang("ES")
 
         t = tracker.Tracker([emitters.Emitter("localhost")], s, "cf", app_id="angry-birds-android")
         evSubject = subject.Subject().set_domain_user_id("1111aaa11a111a11").set_lang("EN")

--- a/snowplow_tracker/test/unit/test_subject.py
+++ b/snowplow_tracker/test/unit/test_subject.py
@@ -42,6 +42,8 @@ class TestSubject(unittest.TestCase):
         s.set_timezone("PST")
         s.set_lang("EN")
         s.set_domain_user_id("domain-user-id")
+        s.set_domain_session_id("domain-session-id")
+        s.set_domain_session_index(1)
         s.set_ip_address("127.0.0.1")
         s.set_useragent("useragent-string")
         s.set_network_user_id("network-user-id")
@@ -57,6 +59,8 @@ class TestSubject(unittest.TestCase):
             "ip": "127.0.0.1",
             "ua": "useragent-string",
             "duid": "domain-user-id",
+            "sid": "domain-session-id",
+            "vid": 1,
             "tnuid": "network-user-id"
         }
         self.assertDictEqual(s.standard_nv_pairs, exp)
@@ -85,5 +89,9 @@ class TestSubject(unittest.TestCase):
             s.standard_nv_pairs["ua"]
         with pytest.raises(KeyError):
             s.standard_nv_pairs["duid"]
+        with pytest.raises(KeyError):
+            s.standard_nv_pairs["sid"]
+        with pytest.raises(KeyError):
+            s.standard_nv_pairs["vid"]
         with pytest.raises(KeyError):
             s.standard_nv_pairs["tnuid"]


### PR DESCRIPTION
Add domain_session_id and domain_session_index to the Subject class in order to include data from the Snowplow cookie.

In addition there is a minor tweak to an unrelated integration test (as if I understand correctly this makes it's intent clearer).