### PR TITLE
Add Python 3.11 to CI tests (close #286)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
         extras-required: [".", ".[redis]"]
 
     services:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN git clone --depth=1 https://github.com/pyenv/pyenv.git $PYENV_ROOT
 RUN git clone --depth=1 https://github.com/pyenv/pyenv-virtualenv.git $PYENV_ROOT/plugins/pyenv-virtualenv
 
-RUN pyenv install 3.5.10 && pyenv install 3.6.14 && pyenv install 3.7.11 && pyenv install 3.8.11 && pyenv install 3.9.6 && pyenv install 3.10.1
+RUN pyenv install 3.5.10 && pyenv install 3.6.14 && pyenv install 3.7.11 && pyenv install 3.8.11 && pyenv install 3.9.6 && pyenv install 3.10.1 && pyenv install 3.11.0
 
 WORKDIR /app
 COPY . .

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -116,6 +116,23 @@ function deploy {
     pip install -r requirements-test.txt
     source deactivate
   fi
+
+  # pyenv install 3.11.0
+  if [ ! -e ~/.pyenv/versions/tracker311 ]; then
+    pyenv virtualenv 3.11.0 tracker311
+    pyenv activate tracker311
+    pip install .
+    pip install -r requirements-test.txt
+    source deactivate
+  fi
+
+  if [ ! -e ~/.pyenv/versions/tracker311redis ]; then
+    pyenv virtualenv 3.11.0 tracker311redis
+    pyenv activate tracker311redis
+    pip install .[redis]
+    pip install -r requirements-test.txt
+    source deactivate
+  fi
 }
 
 
@@ -167,6 +184,15 @@ function run_tests {
   pyenv activate tracker310redis
   pytest
   source deactivate
+
+  pyenv activate tracker311
+  pytest
+  source deactivate
+
+  pyenv activate tracker311redis
+  pytest
+  source deactivate
+
 }
 
 function refresh_deploy {
@@ -182,6 +208,8 @@ function refresh_deploy {
   pyenv uninstall -f tracker39redis
   pyenv uninstall -f tracker310
   pyenv uninstall -f tracker310redis
+  pyenv uninstall -f tracker311
+  pyenv uninstall -f tracker311redis
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
     ],
     install_requires=["requests>=2.25.1,<3.0", "typing_extensions>=3.7.4"],


### PR DESCRIPTION
This PR adds Python 3.11.0 to the CI tests 