### PR TITLE
Make HTTPS the default protocol in emitter (close #14)

### DIFF
--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -133,7 +133,7 @@ class Emitter(object):
         if len(endpoint) < 1:
             raise ValueError("No endpoint provided.")
 
-        if bool(set(PROTOCOLS) & set(endpoint.split("://"))):
+        if bool(PROTOCOLS & set(endpoint.split("://"))):
             endpoint_arr = endpoint.split("://")
             protocol = endpoint_arr[0]
             endpoint = endpoint_arr[1]

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -51,7 +51,7 @@ class Emitter(object):
     def __init__(
             self,
             endpoint: str,
-            protocol: HttpProtocol = "http",
+            protocol: HttpProtocol = "https",
             port: Optional[int] = None,
             method: Method = "get",
             buffer_size: Optional[int] = None,
@@ -60,9 +60,9 @@ class Emitter(object):
             byte_limit: Optional[int] = None,
             request_timeout: Optional[Union[float, Tuple[float, float]]] = None) -> None:
         """
-            :param endpoint:    The collector URL. Don't include "http://" - this is done automatically.
+            :param endpoint:    The collector URL. If protocol is not set in endpoint it will automatically set to "https://" - this is done automatically.
             :type  endpoint:    string
-            :param protocol:    The protocol to use - http or https. Defaults to http.
+            :param protocol:    The protocol to use - http or https. Defaults to https.
             :type  protocol:    protocol
             :param port:        The collector port to connect to
             :type  port:        int | None
@@ -116,7 +116,7 @@ class Emitter(object):
     @staticmethod
     def as_collector_uri(
             endpoint: str,
-            protocol: HttpProtocol = "http",
+            protocol: HttpProtocol = "https",
             port: Optional[int] = None,
             method: Method = "get") -> str:
         """
@@ -132,6 +132,11 @@ class Emitter(object):
         """
         if len(endpoint) < 1:
             raise ValueError("No endpoint provided.")
+
+        if bool(set(PROTOCOLS) & set(endpoint.split("://"))):
+            endpoint_arr = endpoint.split("://")
+            protocol = endpoint_arr[0]
+            endpoint = endpoint_arr[1]
 
         if method == "get":
             path = "/i"

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -54,7 +54,7 @@ class TestEmitters(unittest.TestCase):
 
     def test_init(self) -> None:
         e = Emitter('0.0.0.0')
-        self.assertEqual(e.endpoint, 'http://0.0.0.0/i')
+        self.assertEqual(e.endpoint, 'https://0.0.0.0/i')
         self.assertEqual(e.method, 'get')
         self.assertEqual(e.buffer_size, 1)
         self.assertEqual(e.buffer, [])
@@ -83,24 +83,32 @@ class TestEmitters(unittest.TestCase):
 
     def test_as_collector_uri(self) -> None:
         uri = Emitter.as_collector_uri('0.0.0.0')
-        self.assertEqual(uri, 'http://0.0.0.0/i')
+        self.assertEqual(uri, 'https://0.0.0.0/i')
 
     def test_as_collector_uri_post(self) -> None:
         uri = Emitter.as_collector_uri('0.0.0.0', method="post")
-        self.assertEqual(uri, 'http://0.0.0.0/com.snowplowanalytics.snowplow/tp2')
+        self.assertEqual(uri, 'https://0.0.0.0/com.snowplowanalytics.snowplow/tp2')
 
     def test_as_collector_uri_port(self) -> None:
         uri = Emitter.as_collector_uri('0.0.0.0', port=9090, method="post")
-        self.assertEqual(uri, 'http://0.0.0.0:9090/com.snowplowanalytics.snowplow/tp2')
+        self.assertEqual(uri, 'https://0.0.0.0:9090/com.snowplowanalytics.snowplow/tp2')
 
-    def test_as_collector_uri_https(self) -> None:
-        uri = Emitter.as_collector_uri('0.0.0.0', protocol="https")
-        self.assertEqual(uri, 'https://0.0.0.0/i')
+    def test_as_collector_uri_http(self) -> None:
+        uri = Emitter.as_collector_uri('0.0.0.0', protocol="http")
+        self.assertEqual(uri, 'http://0.0.0.0/i')
 
     def test_as_collector_uri_empty_string(self) -> None:
         with self.assertRaises(ValueError):
             Emitter.as_collector_uri('')
 
+    def test_as_collector_uri_endpoint_protocol(self) -> None:
+        uri = Emitter.as_collector_uri("https://0.0.0.0")
+        self.assertEqual(uri, "https://0.0.0.0/i")
+
+    def test_as_collector_uri_endpoint_protocol_http(self) -> None:
+        uri = Emitter.as_collector_uri("http://0.0.0.0")
+        self.assertEqual(uri, "http://0.0.0.0/i")
+        
     @mock.patch('snowplow_tracker.Emitter.flush')
     def test_input_no_flush(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush


### PR DESCRIPTION
This PR makes https default for the emitter protocol as well as allowing the protocol to be included in the url endpoint.