### PR TITLE
Upgrade set-output in cd (close #294)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Get tag and tracker versions
       id: version
       run: |
-        echo :: "{name}=TAG_VERSION::${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-        echo "##["{name}=PYTHON_TRACKER_VERSION" >> $GITHUB_OUTPUT;]$(python setup.py --version)"
+        echo "TAG_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        echo "PYTHON_TRACKER_VERSION=$(python setup.py --version)" >> $GITHUB_OUTPUT
 
     - name: Fail if version mismatch
       if: ${{ steps.version.outputs.TAG_VERSION != steps.version.outputs.PYTHON_TRACKER_VERSION }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Get tag and tracker versions
       id: version
       run: |
-        echo ::set-output name=TAG_VERSION::${GITHUB_REF#refs/*/}
-        echo "##[set-output name=PYTHON_TRACKER_VERSION;]$(python setup.py --version)"
+        echo :: "{name}=TAG_VERSION::${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        echo "##["{name}=PYTHON_TRACKER_VERSION" >> $GITHUB_OUTPUT;]$(python setup.py --version)"
 
     - name: Fail if version mismatch
       if: ${{ steps.version.outputs.TAG_VERSION != steps.version.outputs.PYTHON_TRACKER_VERSION }}


### PR DESCRIPTION
This PR updates the soon to be deprecated `set-output` command, described [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)