### PR TITLE
Fix Collector URL with trailing '/' (close #300) 

### DIFF
--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -144,6 +144,8 @@ class Emitter(object):
         if len(endpoint) < 1:
             raise ValueError("No endpoint provided.")
 
+        endpoint = endpoint.rstrip('/')
+
         if endpoint.split("://")[0] in PROTOCOLS:
             endpoint_arr = endpoint.split("://")
             protocol = endpoint_arr[0]


### PR DESCRIPTION
This PR fixes an issue in the as_collector_uri() function which doesn't allow a collector URL with a trailing slash.