### PR TITLE
Add Retry for failed events (close #296)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,8 +21,8 @@ jobs:
     - name: Get tag and tracker versions
       id: version
       run: |
-        echo ::set-output name=TAG_VERSION::${GITHUB_REF#refs/*/}
-        echo "##[set-output name=PYTHON_TRACKER_VERSION;]$(python setup.py --version)"
+        echo "TAG_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+        echo "PYTHON_TRACKER_VERSION=$(python setup.py --version)" >> $GITHUB_OUTPUT
 
     - name: Fail if version mismatch
       if: ${{ steps.version.outputs.TAG_VERSION != steps.version.outputs.PYTHON_TRACKER_VERSION }}

--- a/examples/snowplow_app.py
+++ b/examples/snowplow_app.py
@@ -18,7 +18,7 @@ def main():
 
     collector_url = get_url_from_args()
     # Configure Emitter
-    emitter_config = EmitterConfiguration(buffer_size=5)
+    emitter_config = EmitterConfiguration(batch_size=5)
 
     # Configure Tracker
     tracker_config = TrackerConfiguration(encode_base64=True)

--- a/snowplow_tracker/celery/celery_emitter.py
+++ b/snowplow_tracker/celery/celery_emitter.py
@@ -53,9 +53,9 @@ class CeleryEmitter(Emitter):
                 protocol: HttpProtocol = "http",
                 port: Optional[int] = None,
                 method: Method = "post",
-                buffer_size: Optional[int] = None,
+                batch_size: Optional[int] = None,
                 byte_limit: Optional[int] = None) -> None:
-            super(CeleryEmitter, self).__init__(endpoint, protocol, port, method, buffer_size, None, None, byte_limit)
+            super(CeleryEmitter, self).__init__(endpoint, protocol, port, method, batch_size, None, None, byte_limit)
 
             try:
                 # Check whether a custom Celery configuration module named "snowplow_celery_config" exists

--- a/snowplow_tracker/emitter_configuration.py
+++ b/snowplow_tracker/emitter_configuration.py
@@ -26,7 +26,7 @@ from snowplow_tracker.typing import SuccessCallback, FailureCallback
 class EmitterConfiguration(object):
     def __init__(
         self,
-        buffer_size: Optional[int] = None,
+        batch_size: Optional[int] = None,
         on_success: Optional[SuccessCallback] = None,
         on_failure: Optional[FailureCallback] = None,
         byte_limit: Optional[int] = None,
@@ -34,8 +34,8 @@ class EmitterConfiguration(object):
     ) -> None:
         """
         Configuration for the emitter that sends events to the Snowplow collector.
-        :param buffer_size:     The maximum number of queued events before the buffer is flushed. Default is 10.
-        :type  buffer_size:     int | None
+        :param batch_size:     The maximum number of queued events before the buffer is flushed. Default is 10.
+        :type  batch_size:     int | None
         :param on_success:      Callback executed after every HTTP request in a flush has status code 200
                                 Gets passed the number of events flushed.
         :type  on_success:      function | None
@@ -53,26 +53,26 @@ class EmitterConfiguration(object):
         :type request_timeout:  float | tuple | None
         """
 
-        self.buffer_size = buffer_size
+        self.batch_size = batch_size
         self.on_success = on_success
         self.on_failure = on_failure
         self.byte_limit = byte_limit
         self.request_timeout = request_timeout
 
     @property
-    def buffer_size(self) -> Optional[int]:
+    def batch_size(self) -> Optional[int]:
         """
         The maximum number of queued events before the buffer is flushed. Default is 10.
         """
-        return self._buffer_size
+        return self._batch_size
 
-    @buffer_size.setter
-    def buffer_size(self, value: Optional[int]):
+    @batch_size.setter
+    def batch_size(self, value: Optional[int]):
         if isinstance(value, int) and value < 0:
-            raise ValueError("buffer_size must greater than 0")
+            raise ValueError("batch_size must greater than 0")
         if not isinstance(value, int) and value is not None:
-            raise ValueError("buffer_size must be of type int")
-        self._buffer_size = value
+            raise ValueError("batch_size must be of type int")
+        self._batch_size = value
 
     @property
     def on_success(self) -> Optional[SuccessCallback]:

--- a/snowplow_tracker/emitter_configuration.py
+++ b/snowplow_tracker/emitter_configuration.py
@@ -31,6 +31,7 @@ class EmitterConfiguration(object):
         on_failure: Optional[FailureCallback] = None,
         byte_limit: Optional[int] = None,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
+        buffer_capacity: Optional[int] = None
     ) -> None:
         """
         Configuration for the emitter that sends events to the Snowplow collector.
@@ -58,6 +59,7 @@ class EmitterConfiguration(object):
         self.on_failure = on_failure
         self.byte_limit = byte_limit
         self.request_timeout = request_timeout
+        self.buffer_capacity = buffer_capacity
 
     @property
     def batch_size(self) -> Optional[int]:
@@ -127,3 +129,19 @@ class EmitterConfiguration(object):
     @request_timeout.setter
     def request_timeout(self, value: Optional[Union[float, Tuple[float, float]]]):
         self._request_timeout = value
+
+    @property
+    def buffer_capacity(self) -> Optional[int]:
+        """
+        The maximum capacity of the event buffer. The default buffer capacity is 10 000 events.
+                                When the buffer is full new events are lost.
+        """
+        return self._buffer_capacity
+
+    @buffer_capacity.setter
+    def buffer_capacity(self, value: Optional[int]):
+        if isinstance(value, int) and value < 0:
+            raise ValueError("buffer_capacity must greater than 0")
+        if not isinstance(value, int) and value is not None:
+            raise ValueError("buffer_capacity must be of type int")
+        self._buffer_capacity = value

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -230,6 +230,7 @@ class Emitter(object):
             )
         except requests.RequestException as e:
             logger.warning(e)
+            return -1
 
         return r.status_code
 
@@ -246,6 +247,7 @@ class Emitter(object):
             )
         except requests.RequestException as e:
             logger.warning(e)
+            return -1
 
         return r.status_code
 

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -432,6 +432,8 @@ class AsyncEmitter(Emitter):
         on_failure: Optional[FailureCallback] = None,
         thread_count: int = 1,
         byte_limit: Optional[int] = None,
+        max_retry_delay_seconds: int =60,
+        buffer_capacity: int =10000,
     ) -> None:
         """
         :param endpoint:    The collector URL. Don't include "http://" - this is done automatically.
@@ -457,6 +459,11 @@ class AsyncEmitter(Emitter):
         :type  thread_count: int
         :param byte_limit:  The size event list after reaching which queued events will be flushed
         :type  byte_limit:  int | None
+        :param max_retry_delay_seconds:     Set the maximum time between attempts to send failed events to the collector. Default 60 seconds
+        :type max_retry_delay_seconds:      int
+        :param buffer_capacity: The maximum capacity of the event buffer. The default buffer capacity is 10,000 events.
+                                When the buffer is full new events are lost.
+        :type buffer_capacity: int 
         """
         super(AsyncEmitter, self).__init__(
             endpoint,
@@ -467,6 +474,8 @@ class AsyncEmitter(Emitter):
             on_success,
             on_failure,
             byte_limit,
+            max_retry_delay_seconds,
+            buffer_capacity
         )
         self.queue = Queue()
         for i in range(thread_count):

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -365,7 +365,7 @@ class Emitter(object):
 
         # Repeatable create new timer
         if flush_now:
-            self.flush()
+            self._flush_now()
         self.timer = threading.Timer(timeout, self.set_flush_timer, [timeout, True])
         self.timer.daemon = True
         self.timer.start()

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -436,7 +436,7 @@ class AsyncEmitter(Emitter):
         buffer_capacity: int =10000,
     ) -> None:
         """
-        :param endpoint:    The collector URL. Don't include "http://" - this is done automatically.
+        :param endpoint:    The collector URL. If protocol is not set in endpoint it will automatically set to "https://" - this is done automatically.
         :type  endpoint:    string
         :param protocol:    The protocol to use - http or https. Defaults to http.
         :type  protocol:    protocol

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -345,6 +345,18 @@ class Emitter(object):
         if self.timer is not None:
             return 
 
+    def set_flush_timer(self, timeout: float, flush_now: bool = False) -> None:
+        """
+            Set an interval at which the buffer will be flushed
+            :param timeout:   interval in seconds
+            :type  timeout:   int | float
+            :param flush_now: immediately flush buffer
+            :type  flush_now: bool
+        """
+
+        # Repeatable create new timer
+        if flush_now:
+            self.flush()
         self.timer = threading.Timer(timeout, self.set_flush_timer, [timeout, True])
         self.timer.daemon = True
         self.timer.start()

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -69,8 +69,7 @@ class Emitter(object):
         on_failure: Optional[FailureCallback] = None,
         byte_limit: Optional[int] = None,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
-        retry_codes={},
-        max_retry=60,
+        max_retry_delay_seconds=60,
     ) -> None:
         """
         :param endpoint:    The collector URL. If protocol is not set in endpoint it will automatically set to "https://" - this is done automatically.
@@ -98,6 +97,8 @@ class Emitter(object):
                                  applies to both "connect" AND "read" timeout, or as tuple with two float values
                                  which specify the "connect" and "read" timeouts separately
         :type request_timeout:  float | tuple | None
+        :param max_retry_delay_seconds:     Set the maximum time between attempts to send failed events to the collector. Default 60 seconds
+        :type max_retry_delay_seconds:      int
         """
         one_of(protocol, PROTOCOLS)
         one_of(method, METHODS)
@@ -124,8 +125,7 @@ class Emitter(object):
 
         self.timer = None
 
-        self.retry_codes = retry_codes
-        self.max_retry = max_retry
+        self.max_retry_delay_seconds = max_retry_delay_seconds
         self.retry_delay = 0
 
         logger.info("Emitter initialized with endpoint " + self.endpoint)
@@ -377,7 +377,7 @@ class Emitter(object):
             Sets a delay to retry failed events
         """
         random_noise = random.random()
-        self.retry_delay = min(self.retry_delay * 2 + random_noise, self.max_retry)
+        self.retry_delay = min(self.retry_delay * 2 + random_noise, self.max_retry_delay_seconds)
 
     def reset_retry_delay(self) -> None:
         """

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -100,8 +100,8 @@ class Emitter(object):
         :type request_timeout:  float | tuple | None
         :param max_retry_delay_seconds:     Set the maximum time between attempts to send failed events to the collector. Default 60 seconds
         :type max_retry_delay_seconds:      int
-        :param buffer_capacity: The default buffer capacity is 10 000 events.
-                                When the buffer is full (due to network outage), new events are lost.
+        :param buffer_capacity: The maximum capacity of the event buffer. The default buffer capacity is 10 000 events.
+                                When the buffer is full new events are lost.
         :type buffer_capacity: int 
         """
         one_of(protocol, PROTOCOLS)

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -193,6 +193,7 @@ class Emitter(object):
                 self.buffer.append(payload)
 
             if self.reached_limit():
+                self.flush()
                 threading.Timer(self.retry_delay, self.flush())
 
     def reached_limit(self) -> bool:
@@ -271,7 +272,7 @@ class Emitter(object):
         This is guaranteed to be blocking, not asynchronous.
         """
         logger.debug("Starting synchronous flush...")
-        Emitter.flush(self)
+        Emitter._flush_now(self)
         logger.info("Finished synchronous flush")
 
     @staticmethod

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -342,7 +342,7 @@ class Emitter(object):
         """
 
         if flush_now:
-            self.retry_timer = None
+            self._cancel_retry_timer()
             self._flush_now()
             return
         
@@ -441,6 +441,14 @@ class Emitter(object):
             :rtype: bool 
         """
         return len(self.buffer) >= self.buffer_capacity
+
+    def _cancel_retry_timer(self) -> None:
+        """
+            Cancels a retry timer
+        """
+        if self.retry_timer is not None:
+            self.retry_timer = None
+
 
 class AsyncEmitter(Emitter):
     """

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -325,7 +325,7 @@ class Emitter(object):
 
             if self.should_retry(status_code):
                 self.set_retry_delay()
-                self.failure_retry(failure_events)
+                self._retry_failed_events(failure_events)
             else:
                 self.reset_retry_delay()
         else:
@@ -395,7 +395,7 @@ class Emitter(object):
         for event in events:
             update(event)
 
-    def should_retry(self, status_code: int) -> bool:
+    def _should_retry(self, status_code: int) -> bool:
         """
             Checks if a request should be retried
             
@@ -408,20 +408,20 @@ class Emitter(object):
 
         return not status_code in [400, 401, 403, 410, 422]
 
-    def set_retry_delay(self) -> None:
+    def _set_retry_delay(self) -> None:
         """
             Sets a delay to retry failed events
         """
         random_noise = random.random()
         self.retry_delay = min(self.retry_delay * 2 + random_noise, self.max_retry_delay_seconds)
 
-    def reset_retry_delay(self) -> None:
+    def _reset_retry_delay(self) -> None:
         """
             Resets retry delay to 0
         """
         self.retry_delay = 0
 
-    def failure_retry(self, failed_events) -> None:
+    def _retry_failed_events(self, failed_events) -> None:
         """
             Adds failed events back to the buffer to retry 
 
@@ -434,7 +434,7 @@ class Emitter(object):
 
         self._set_retry_timer(self.retry_delay)
 
-    def buffer_capacity_reached(self):
+    def _buffer_capacity_reached(self):
         return len(self.buffer) >= self.buffer_capacity
 
 class AsyncEmitter(Emitter):

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -367,9 +367,6 @@ class Emitter(object):
         if Emitter.is_good_status_code(status_code):
             return False
 
-        if status_code in self.retry_codes.keys():
-            return self.retry_codes[status_code]
-
         return not status_code in [400, 401, 403, 410, 422]
 
     def set_retry_delay(self) -> None:

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -223,8 +223,8 @@ class Emitter(object):
 
     def _flush_now(self) -> None:
          with self.lock:
-            if self.retry_timer:
-                return
+            
+            self._cancel_retry_timer()
 
             send_events = self.buffer
             self.buffer = []

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -194,7 +194,7 @@ class Emitter(object):
 
             if self.reached_limit():
                 self.flush()
-                threading.Timer(self.retry_delay, self.flush())
+                # threading.Timer(self.retry_delay, self.flush())
 
     def reached_limit(self) -> bool:
         """

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -194,7 +194,6 @@ class Emitter(object):
 
             if self.reached_limit():
                 self.flush()
-                # threading.Timer(self.retry_delay, self.flush())
 
     def reached_limit(self) -> bool:
         """

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -365,7 +365,7 @@ class Emitter(object):
 
         # Repeatable create new timer
         if flush_now:
-            self._flush_now()
+            self.flush()
         self.timer = threading.Timer(timeout, self.set_flush_timer, [timeout, True])
         self.timer.daemon = True
         self.timer.start()
@@ -506,7 +506,7 @@ class AsyncEmitter(Emitter):
 
     def sync_flush(self) -> None:
         while True:
-            self.flush()
+            self._flush_now()
             self.queue.join()
             if len(self.buffer) < 1:
                 break

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -212,7 +212,8 @@ class Emitter(object):
         """
         Sends all events in the buffer to the collector.
         """
-        with self.lock:
+    def _flush_now(self) -> None:
+         with self.lock:
             if self.timer:
                 return
 

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -357,6 +357,13 @@ class Emitter(object):
             update(event)
 
     def should_retry(self, status_code: int) -> bool:
+        """
+            Checks if a request should be retried
+            
+            :param  status_code: Response status code
+            :type   status_code: int
+            :rtype: bool
+        """
         if Emitter.is_good_status_code(status_code):
             return False
 
@@ -366,13 +373,25 @@ class Emitter(object):
         return not status_code in [400, 401, 403, 410, 422]
 
     def set_retry_delay(self) -> None:
+        """
+            Sets a delay to retry failed events
+        """
         random_noise = random.random()
         self.retry_delay = min(self.retry_delay * 2 + random_noise, self.max_retry)
 
     def reset_retry_delay(self) -> None:
+        """
+            Resets retry delay to 0
+        """
         self.retry_delay = 0
 
-    def failure_retry(self, failed_events):
+    def failure_retry(self, failed_events) -> None:
+        """
+            Adds failed events back to the buffer to retry 
+
+            :param  failed_events: List of failed events
+            :type   List
+        """
         for event in failed_events:
             if not event in self.buffer:
                 self.buffer.append(event)

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -217,13 +217,13 @@ class Emitter(object):
             delay = self.retry_delay
 
         if delay > 0:
-            self.set_flush_timer(delay)
+            return
         else:
             self._flush_now()
 
     def _flush_now(self) -> None:
          with self.lock:
-            if self.timer:
+            if self.retry_timer:
                 return
 
             send_events = self.buffer

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -299,6 +299,11 @@ class Emitter(object):
             if self.on_failure is not None and len(failure_events) > 0:
                 self.on_failure(len(success_events), failure_events)
 
+            if self.should_retry(status_code):
+                self.set_retry_delay()
+                self.failure_retry(failure_events)
+            else:
+                self.reset_retry_delay()
         else:
             logger.info("Skipping flush since buffer is empty")
 

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -341,7 +341,6 @@ class Emitter(object):
         :type  flush_now: bool
         """
 
-        # Repeatable create new timer
         if flush_now:
             self.retry_timer = None
             self._flush_now()
@@ -349,10 +348,11 @@ class Emitter(object):
         
         if self.retry_timer is not None:
             return 
-
-        self.timer = threading.Timer(timeout, self._set_retry_timer, [timeout, True])
-        self.timer.daemon = True
-        self.timer.start()
+        
+        # Create new timer
+        self.retry_timer = threading.Timer(timeout, self._set_retry_timer, [timeout, True])
+        self.retry_timer.daemon = True
+        self.retry_timer.start()
 
     def set_flush_timer(self, timeout: float, flush_now: bool = False) -> None:
         """

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -340,7 +340,11 @@ class Emitter(object):
         # Repeatable create new timer
         if flush_now:
             self.timer = None
-            self.flush()
+            self._flush_now()
+        
+        if self.timer is not None:
+            return 
+
         self.timer = threading.Timer(timeout, self.set_flush_timer, [timeout, True])
         self.timer.daemon = True
         self.timer.start()

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -323,11 +323,11 @@ class Emitter(object):
             if self.on_failure is not None and len(failure_events) > 0:
                 self.on_failure(len(success_events), failure_events)
 
-            if self.should_retry(status_code):
-                self.set_retry_delay()
+            if self._should_retry(status_code):
+                self._set_retry_delay()
                 self._retry_failed_events(failure_events)
             else:
-                self.reset_retry_delay()
+                self._reset_retry_delay()
         else:
             logger.info("Skipping flush since buffer is empty")
 
@@ -429,12 +429,17 @@ class Emitter(object):
             :type   List
         """
         for event in failed_events:
-            if not event in self.buffer and not self.buffer_capacity_reached():
+            if not event in self.buffer and not self._buffer_capacity_reached():
                 self.buffer.append(event)
 
         self._set_retry_timer(self.retry_delay)
 
-    def _buffer_capacity_reached(self):
+    def _buffer_capacity_reached(self) -> bool:
+        """
+            Returns true if buffer capacity is reached
+
+            :rtype: bool 
+        """
         return len(self.buffer) >= self.buffer_capacity
 
 class AsyncEmitter(Emitter):

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -212,6 +212,11 @@ class Emitter(object):
         """
         Sends all events in the buffer to the collector.
         """
+        if self.retry_delay > 0:
+            self.set_flush_timer(self.retry_delay)
+        else:
+            self._flush_now()
+
     def _flush_now(self) -> None:
          with self.lock:
             if self.timer:

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -357,6 +357,8 @@ class Emitter(object):
         random_noise = random.random()
         self.retry_delay = min(self.retry_delay * 2 + random_noise, self.max_retry)
 
+    def reset_retry_delay(self) -> None:
+        self.retry_delay = 0
 
 class AsyncEmitter(Emitter):
     """

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -24,6 +24,7 @@ import logging
 import time
 import threading
 import requests
+import random
 from typing import Optional, Union, Tuple
 from queue import Queue
 
@@ -69,6 +70,7 @@ class Emitter(object):
         byte_limit: Optional[int] = None,
         request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
         retry_codes={},
+        max_retry=60,
     ) -> None:
         """
         :param endpoint:    The collector URL. If protocol is not set in endpoint it will automatically set to "https://" - this is done automatically.
@@ -123,6 +125,8 @@ class Emitter(object):
         self.timer = None
 
         self.retry_codes = retry_codes
+        self.max_retry = max_retry
+        self.retry_delay = 0
 
         logger.info("Emitter initialized with endpoint " + self.endpoint)
 
@@ -348,6 +352,10 @@ class Emitter(object):
             return self.retry_codes[status_code]
 
         return not status_code in [400, 401, 403, 410, 422]
+
+    def set_retry_delay(self) -> None:
+        random_noise = random.random()
+        self.retry_delay = min(self.retry_delay * 2 + random_noise, self.max_retry)
 
 
 class AsyncEmitter(Emitter):

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -213,8 +213,11 @@ class Emitter(object):
         """
         Sends all events in the buffer to the collector.
         """
-        if self.retry_delay > 0:
-            self.set_flush_timer(self.retry_delay)
+        with self.lock:
+            delay = self.retry_delay
+
+        if delay > 0:
+            self.set_flush_timer(delay)
         else:
             self._flush_now()
 

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -360,6 +360,14 @@ class Emitter(object):
     def reset_retry_delay(self) -> None:
         self.retry_delay = 0
 
+    def failure_retry(self, failed_events):
+        for event in failed_events:
+            if not event in self.buffer:
+                self.buffer.append(event)
+
+        self.set_flush_timer(self.retry_delay)
+
+
 class AsyncEmitter(Emitter):
     """
     Uses threads to send HTTP requests asynchronously

--- a/snowplow_tracker/snowplow.py
+++ b/snowplow_tracker/snowplow.py
@@ -77,7 +77,7 @@ class Snowplow:
         emitter = Emitter(
             endpoint,
             method=method,
-            buffer_size=emitter_config.buffer_size,
+            batch_size=emitter_config.batch_size,
             on_success=emitter_config.on_success,
             on_failure=emitter_config.on_failure,
             byte_limit=emitter_config.byte_limit,

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -36,7 +36,7 @@ from snowplow_tracker.redis import redis_emitter
 
 querystrings = [""]
 
-default_emitter = emitters.Emitter("localhost", protocol="http", port=80, buffer_size=1)
+default_emitter = emitters.Emitter("localhost", protocol="http", port=80, batch_size=1)
 
 get_emitter = emitters.Emitter("localhost", protocol="http", port=80, method='get')
 
@@ -333,7 +333,7 @@ class IntegrationTest(unittest.TestCase):
             self.assertEqual(request["data"][0][key], expected_fields[key])
 
     def test_post_batched(self) -> None:
-        default_emitter = emitters.Emitter("localhost", protocol="http", port=80, buffer_size=2)
+        default_emitter = emitters.Emitter("localhost", protocol="http", port=80, batch_size=2)
         t = tracker.Tracker(default_emitter, default_subject)
         with HTTMock(pass_post_response_content):
             t.track_struct_event("Test", "A")
@@ -343,7 +343,7 @@ class IntegrationTest(unittest.TestCase):
 
     @freeze_time("2021-04-19 00:00:01")  # unix: 1618790401000
     def test_timestamps(self) -> None:
-        emitter = emitters.Emitter("localhost", protocol="http", port=80, buffer_size=3)
+        emitter = emitters.Emitter("localhost", protocol="http", port=80, batch_size=3)
         t = tracker.Tracker([emitter], default_subject)
         with HTTMock(pass_post_response_content):
             t.track_page_view("localhost", "stamp0", None, tstamp=None)
@@ -363,7 +363,7 @@ class IntegrationTest(unittest.TestCase):
             self.assertEqual(request["data"][i].get("stm"), expected_timestamps[i]["stm"])
 
     def test_bytelimit(self) -> None:
-        default_emitter = emitters.Emitter("localhost", protocol="http", port=80, buffer_size=5, byte_limit=420)
+        default_emitter = emitters.Emitter("localhost", protocol="http", port=80, batch_size=5, byte_limit=420)
         t = tracker.Tracker(default_emitter, default_subject)
         with HTTMock(pass_post_response_content):
             t.track_struct_event("Test", "A")       # 140 bytes

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -46,6 +46,14 @@ def mocked_http_success(*args: Any) -> bool:
 def mocked_http_failure(*args: Any) -> bool:
     return False
 
+def mocked_http_response_success(*args: Any) -> int:
+    return 200
+
+def mocked_http_response_failure(*args: Any) -> int:
+    return 400
+
+def mocked_http_response_failure_retry(*args: Any) -> int:
+    return 500
 
 class TestEmitters(unittest.TestCase):
 

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -223,7 +223,7 @@ class TestEmitters(unittest.TestCase):
             reduced = reduced and "stm" in ev.keys() and ev["stm"] == "1618358402000"
         self.assertTrue(reduced)
 
-    @mock.patch('snowplow_tracker.Emitter.flush')
+    @mock.patch('snowplow_tracker.Emitter._flush_now')
     def test_flush_timer(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush
 

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -235,7 +235,7 @@ class TestEmitters(unittest.TestCase):
         e.set_flush_timer(3)
         self.assertEqual(len(e.buffer), 3)
         time.sleep(5)
-        self.assertEqual(mok_flush.call_count, 1)
+        self.assertGreaterEqual(mok_flush.call_count, 1)
 
     @mock.patch('snowplow_tracker.Emitter.http_get')
     def test_send_events_get_success(self, mok_http_get: Any) -> None:

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -64,7 +64,7 @@ class TestEmitters(unittest.TestCase):
         e = Emitter('0.0.0.0')
         self.assertEqual(e.endpoint, 'https://0.0.0.0/com.snowplowanalytics.snowplow/tp2')
         self.assertEqual(e.method, 'post')
-        self.assertEqual(e.buffer_size, 10)
+        self.assertEqual(e.batch_size, 10)
         self.assertEqual(e.buffer, [])
         self.assertIsNone(e.byte_limit)
         self.assertIsNone(e.bytes_queued)
@@ -73,13 +73,13 @@ class TestEmitters(unittest.TestCase):
         self.assertIsNone(e.timer)
         self.assertIsNone(e.request_timeout)
 
-    def test_init_buffer_size(self) -> None:
-        e = Emitter('0.0.0.0', buffer_size=10)
-        self.assertEqual(e.buffer_size, 10)
+    def test_init_batch_size(self) -> None:
+        e = Emitter('0.0.0.0', batch_size=10)
+        self.assertEqual(e.batch_size, 10)
 
     def test_init_post(self) -> None:
         e = Emitter('0.0.0.0')
-        self.assertEqual(e.buffer_size, DEFAULT_MAX_LENGTH)
+        self.assertEqual(e.batch_size, DEFAULT_MAX_LENGTH)
 
     def test_init_byte_limit(self) -> None:
         e = Emitter('0.0.0.0', byte_limit=512)
@@ -121,7 +121,7 @@ class TestEmitters(unittest.TestCase):
     def test_input_no_flush(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush
 
-        e = Emitter('0.0.0.0', method="get", buffer_size=2)
+        e = Emitter('0.0.0.0', method="get", batch_size=2)
         nvPairs = {"n0": "v0", "n1": "v1"}
         e.input(nvPairs)
 
@@ -135,7 +135,7 @@ class TestEmitters(unittest.TestCase):
     def test_input_flush_byte_limit(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush
 
-        e = Emitter('0.0.0.0', method="get", buffer_size=2, byte_limit=16)
+        e = Emitter('0.0.0.0', method="get", batch_size=2, byte_limit=16)
         nvPairs = {"n0": "v0", "n1": "v1"}
         e.input(nvPairs)
 
@@ -148,7 +148,7 @@ class TestEmitters(unittest.TestCase):
     def test_input_flush_buffer(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush
 
-        e = Emitter('0.0.0.0', method="get", buffer_size=2, byte_limit=1024)
+        e = Emitter('0.0.0.0', method="get", batch_size=2, byte_limit=1024)
         nvPairs = {"n0": "v0", "n1": "v1"}
         e.input(nvPairs)
 
@@ -167,7 +167,7 @@ class TestEmitters(unittest.TestCase):
     def test_input_bytes_queued(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush
 
-        e = Emitter('0.0.0.0', method="get", buffer_size=2, byte_limit=1024)
+        e = Emitter('0.0.0.0', method="get", batch_size=2, byte_limit=1024)
         nvPairs = {"n0": "v0", "n1": "v1"}
         e.input(nvPairs)
 
@@ -191,7 +191,7 @@ class TestEmitters(unittest.TestCase):
     def test_flush(self, mok_send_events: Any) -> None:
         mok_send_events.side_effect = mocked_send_events
 
-        e = Emitter('0.0.0.0', buffer_size=2, byte_limit=None)
+        e = Emitter('0.0.0.0', batch_size=2, byte_limit=None)
         nvPairs = {"n": "v"}
         e.input(nvPairs)
         e.input(nvPairs)
@@ -203,7 +203,7 @@ class TestEmitters(unittest.TestCase):
     def test_flush_bytes_queued(self, mok_send_events: Any) -> None:
         mok_send_events.side_effect = mocked_send_events
 
-        e = Emitter('0.0.0.0', buffer_size=2, byte_limit=256)
+        e = Emitter('0.0.0.0', batch_size=2, byte_limit=256)
         nvPairs = {"n": "v"}
         e.input(nvPairs)
         e.input(nvPairs)
@@ -227,7 +227,7 @@ class TestEmitters(unittest.TestCase):
     def test_flush_timer(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush
 
-        e = Emitter('0.0.0.0', buffer_size=10)
+        e = Emitter('0.0.0.0', batch_size=10)
         ev_list = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         for i in ev_list:
             e.input(i)
@@ -243,7 +243,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', method="get", buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', method="get", batch_size=10, on_success=mok_success, on_failure=mok_failure)
 
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
@@ -256,7 +256,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', method="get", buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', method="get", batch_size=10, on_success=mok_success, on_failure=mok_failure)
 
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
@@ -269,7 +269,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', batch_size=10, on_success=mok_success, on_failure=mok_failure)
 
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
@@ -282,7 +282,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', batch_size=10, on_success=mok_success, on_failure=mok_failure)
 
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
@@ -313,7 +313,7 @@ class TestEmitters(unittest.TestCase):
     def test_async_emitter_input(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush
 
-        ae = AsyncEmitter('0.0.0.0', port=9090, method="get", buffer_size=3, thread_count=5)
+        ae = AsyncEmitter('0.0.0.0', port=9090, method="get", batch_size=3, thread_count=5)
         self.assertTrue(ae.queue.empty())
 
         ae.input({"a": "aa"})
@@ -329,7 +329,7 @@ class TestEmitters(unittest.TestCase):
     def test_async_emitter_sync_flash(self, mok_send_events: Any) -> None:
         mok_send_events.side_effect = mocked_send_events
 
-        ae = AsyncEmitter('0.0.0.0', port=9090, method="get", buffer_size=3, thread_count=5, byte_limit=1024)
+        ae = AsyncEmitter('0.0.0.0', port=9090, method="get", batch_size=3, thread_count=5, byte_limit=1024)
         self.assertTrue(ae.queue.empty())
 
         ae.input({"a": "aa"})
@@ -349,7 +349,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        ae = AsyncEmitter('0.0.0.0', method="get", buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        ae = AsyncEmitter('0.0.0.0', method="get", batch_size=10, on_success=mok_success, on_failure=mok_failure)
 
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         ae.send_events(evBuffer)
@@ -362,7 +362,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        ae = AsyncEmitter('0.0.0.0', method="get", buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        ae = AsyncEmitter('0.0.0.0', method="get", batch_size=10, on_success=mok_success, on_failure=mok_failure)
 
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         ae.send_events(evBuffer)
@@ -375,7 +375,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        ae = Emitter('0.0.0.0', buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        ae = Emitter('0.0.0.0', batch_size=10, on_success=mok_success, on_failure=mok_failure)
 
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         ae.send_events(evBuffer)
@@ -388,7 +388,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        ae = Emitter('0.0.0.0', buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        ae = Emitter('0.0.0.0', batch_size=10, on_success=mok_success, on_failure=mok_failure)
 
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         ae.send_events(evBuffer)
@@ -401,7 +401,7 @@ class TestEmitters(unittest.TestCase):
         mok_flush.side_effect = mocked_flush
 
         payload = {"unicode": u'\u0107', "alsoAscii": "abc"}
-        ae = AsyncEmitter('0.0.0.0', method="get", buffer_size=2)
+        ae = AsyncEmitter('0.0.0.0', method="get", batch_size=2)
         ae.input(payload)
 
         self.assertEqual(len(ae.buffer), 1)
@@ -412,7 +412,7 @@ class TestEmitters(unittest.TestCase):
         mok_flush.side_effect = mocked_flush
 
         payload = {"unicode": u'\u0107', "alsoAscii": "abc"}
-        ae = AsyncEmitter('0.0.0.0', buffer_size=2)
+        ae = AsyncEmitter('0.0.0.0', batch_size=2)
         ae.input(payload)
 
         self.assertEqual(len(ae.buffer), 1)
@@ -424,7 +424,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', buffer_size=10, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', batch_size=10, on_success=mok_success, on_failure=mok_failure)
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
         
@@ -440,7 +440,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', method='get', buffer_size=1, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', method='get', batch_size=1, on_success=mok_success, on_failure=mok_failure)
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
         
@@ -456,7 +456,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', method='get', buffer_size=1, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', method='get', batch_size=1, on_success=mok_success, on_failure=mok_failure)
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
         
@@ -469,7 +469,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', method='get', buffer_size=1, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', method='get', batch_sizebatch_size=1, on_success=mok_success, on_failure=mok_failure)
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
         

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -239,7 +239,7 @@ class TestEmitters(unittest.TestCase):
 
     @mock.patch('snowplow_tracker.Emitter.http_get')
     def test_send_events_get_success(self, mok_http_get: Any) -> None:
-        mok_http_get.side_effect = mocked_http_success
+        mok_http_get.side_effect = mocked_http_response_success
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
@@ -252,7 +252,7 @@ class TestEmitters(unittest.TestCase):
 
     @mock.patch('snowplow_tracker.Emitter.http_get')
     def test_send_events_get_failure(self, mok_http_get: Any) -> None:
-        mok_http_get.side_effect = mocked_http_failure
+        mok_http_get.side_effect = mocked_http_response_failure
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
@@ -265,7 +265,7 @@ class TestEmitters(unittest.TestCase):
 
     @mock.patch('snowplow_tracker.Emitter.http_post')
     def test_send_events_post_success(self, mok_http_post: Any) -> None:
-        mok_http_post.side_effect = mocked_http_success
+        mok_http_post.side_effect = mocked_http_response_success
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
@@ -278,7 +278,7 @@ class TestEmitters(unittest.TestCase):
 
     @mock.patch('snowplow_tracker.Emitter.http_post')
     def test_send_events_post_failure(self, mok_http_post: Any) -> None:
-        mok_http_post.side_effect = mocked_http_failure
+        mok_http_post.side_effect = mocked_http_response_failure
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
@@ -293,7 +293,8 @@ class TestEmitters(unittest.TestCase):
     def test_http_post_connect_timeout_error(self, mok_post_request: Any) -> None:
         mok_post_request.side_effect = ConnectTimeout
         e = Emitter('0.0.0.0')
-        post_succeeded = e.http_post("dummy_string")
+        response = e.http_post("dummy_string")
+        post_succeeded = Emitter.is_good_status_code(response)
 
         self.assertFalse(post_succeeded)
 
@@ -301,8 +302,8 @@ class TestEmitters(unittest.TestCase):
     def test_http_get_connect_timeout_error(self, mok_post_request: Any) -> None:
         mok_post_request.side_effect = ConnectTimeout
         e = Emitter('0.0.0.0', method='get')
-        get_succeeded = e.http_get({"a": "b"})
-
+        response = e.http_get({"a": "b"})
+        get_succeeded = Emitter.is_good_status_code(response)
         self.assertFalse(get_succeeded)
 
     ###
@@ -344,7 +345,7 @@ class TestEmitters(unittest.TestCase):
 
     @mock.patch('snowplow_tracker.Emitter.http_get')
     def test_async_send_events_get_success(self, mok_http_get: Any) -> None:
-        mok_http_get.side_effect = mocked_http_success
+        mok_http_get.side_effect = mocked_http_response_success
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
@@ -357,7 +358,7 @@ class TestEmitters(unittest.TestCase):
 
     @mock.patch('snowplow_tracker.Emitter.http_get')
     def test_async_send_events_get_failure(self, mok_http_get: Any) -> None:
-        mok_http_get.side_effect = mocked_http_failure
+        mok_http_get.side_effect = mocked_http_response_failure
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
@@ -370,7 +371,7 @@ class TestEmitters(unittest.TestCase):
 
     @mock.patch('snowplow_tracker.Emitter.http_post')
     def test_async_send_events_post_success(self, mok_http_post: Any) -> None:
-        mok_http_post.side_effect = mocked_http_success
+        mok_http_post.side_effect = mocked_http_response_success
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
@@ -383,7 +384,7 @@ class TestEmitters(unittest.TestCase):
 
     @mock.patch('snowplow_tracker.Emitter.http_post')
     def test_async_send_events_post_failure(self, mok_http_post: Any) -> None:
-        mok_http_post.side_effect = mocked_http_failure
+        mok_http_post.side_effect = mocked_http_response_failure
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -469,7 +469,7 @@ class TestEmitters(unittest.TestCase):
         mok_success = mock.Mock(return_value="success mocked")
         mok_failure = mock.Mock(return_value="failure mocked")
 
-        e = Emitter('0.0.0.0', method='get', batch_sizebatch_size=1, on_success=mok_success, on_failure=mok_failure)
+        e = Emitter('0.0.0.0', method='get', batch_size=1, on_success=mok_success, on_failure=mok_failure)
         evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
         e.send_events(evBuffer)
         

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -449,3 +449,29 @@ class TestEmitters(unittest.TestCase):
 
         mok_failure.assert_called_with(0, evBuffer)
         mok_success.assert_called_with(evBuffer)
+
+    @mock.patch('snowplow_tracker.Emitter.http_get')
+    def test_send_events_get_no_retry(self, mok_http_get: Any) -> None:
+        mok_http_get.side_effect = mocked_http_response_failure
+        mok_success = mock.Mock(return_value="success mocked")
+        mok_failure = mock.Mock(return_value="failure mocked")
+
+        e = Emitter('0.0.0.0', method='get', buffer_size=1, on_success=mok_success, on_failure=mok_failure)
+        evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
+        e.send_events(evBuffer)
+        
+        mok_failure.assert_called_once_with(0, evBuffer)
+        mok_success.assert_not_called()
+
+    @mock.patch('snowplow_tracker.Emitter.http_post')
+    def test_send_events_post_no_retry(self, mok_http_post: Any) -> None:
+        mok_http_post.side_effect = mocked_http_response_failure
+        mok_success = mock.Mock(return_value="success mocked")
+        mok_failure = mock.Mock(return_value="failure mocked")
+
+        e = Emitter('0.0.0.0', method='get', buffer_size=1, on_success=mok_success, on_failure=mok_failure)
+        evBuffer = [{"a": "aa"}, {"b": "bb"}, {"c": "cc"}]
+        e.send_events(evBuffer)
+        
+        mok_failure.assert_called_once_with(0, evBuffer)
+        mok_success.assert_not_called()

--- a/snowplow_tracker/test/unit/test_emitters.py
+++ b/snowplow_tracker/test/unit/test_emitters.py
@@ -70,7 +70,7 @@ class TestEmitters(unittest.TestCase):
         self.assertIsNone(e.bytes_queued)
         self.assertIsNone(e.on_success)
         self.assertIsNone(e.on_failure)
-        self.assertIsNone(e.timer)
+        self.assertFalse(e.timer.is_active())
         self.assertIsNone(e.request_timeout)
 
     def test_init_batch_size(self) -> None:
@@ -223,7 +223,7 @@ class TestEmitters(unittest.TestCase):
             reduced = reduced and "stm" in ev.keys() and ev["stm"] == "1618358402000"
         self.assertTrue(reduced)
 
-    @mock.patch('snowplow_tracker.Emitter._flush_now')
+    @mock.patch('snowplow_tracker.Emitter.flush')
     def test_flush_timer(self, mok_flush: Any) -> None:
         mok_flush.side_effect = mocked_flush
 


### PR DESCRIPTION
This PR adds retry functionality to the Python tracker. 

Currently, the tracker will retry sending any failed event indefinitely excluding a set of 40X codes. In a future PR this will become a customisable list of retry codes.

