### PR TITLE
Issue/298 rename unstruct event

### DIFF
--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -153,10 +153,10 @@ class IntegrationTest(unittest.TestCase):
         for key in expected_fields:
             self.assertEqual(from_querystring(key, querystrings[-1]), expected_fields[key])
 
-    def test_integration_unstruct_event_non_base64(self) -> None:
+    def test_integration_self_describing_event_non_base64(self) -> None:
         t = tracker.Tracker([get_emitter], default_subject, encode_base64=False)
         with HTTMock(pass_response_content):
-            t.track_unstruct_event(SelfDescribingJson("iglu:com.acme/viewed_product/jsonschema/2-0-2", {"product_id": "ASO01043", "price$flt": 49.95, "walrus$tms": 1000}))
+            t.track_self_describing_event(SelfDescribingJson("iglu:com.acme/viewed_product/jsonschema/2-0-2", {"product_id": "ASO01043", "price$flt": 49.95, "walrus$tms": 1000}))
         expected_fields = {"e": "ue"}
         for key in expected_fields:
             self.assertEqual(from_querystring(key, querystrings[-1]), expected_fields[key])
@@ -167,10 +167,10 @@ class IntegrationTest(unittest.TestCase):
             "data": {"schema": "iglu:com.acme/viewed_product/jsonschema/2-0-2", "data": {"product_id": "ASO01043", "price$flt": 49.95, "walrus$tms": 1000}}
         })
 
-    def test_integration_unstruct_event_base64(self) -> None:
+    def test_integration_self_describing_event_base64(self) -> None:
         t = tracker.Tracker([get_emitter], default_subject, encode_base64=True)
         with HTTMock(pass_response_content):
-            t.track_unstruct_event(SelfDescribingJson("iglu:com.acme/viewed_product/jsonschema/2-0-2", {"product_id": "ASO01043", "price$flt": 49.95, "walrus$tms": 1000}))
+            t.track_self_describing_event(SelfDescribingJson("iglu:com.acme/viewed_product/jsonschema/2-0-2", {"product_id": "ASO01043", "price$flt": 49.95, "walrus$tms": 1000}))
         expected_fields = {"e": "ue"}
         for key in expected_fields:
             self.assertEqual(from_querystring(key, querystrings[-1]), expected_fields[key])

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -159,7 +159,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(tstamp, 1000)  # 1970-01-01 00:00:01 in ms
 
     @mock.patch("snowplow_tracker.Tracker.track")
-    def test_alias_of_track_unstruct_event(self, mok_track: Any) -> None:
+    def test_alias_of_track_self_describing_event(self, mok_track: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
@@ -441,7 +441,7 @@ class TestTracker(unittest.TestCase):
     ###
 
     @mock.patch("snowplow_tracker.Tracker.complete_payload")
-    def test_track_unstruct_event(self, mok_complete_payload: Any) -> None:
+    def test_track_self_describing_event(self, mok_complete_payload: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
@@ -449,7 +449,7 @@ class TestTracker(unittest.TestCase):
 
         t = Tracker(e, encode_base64=False)
         evJson = SelfDescribingJson("test.sde.schema", {"n": "v"})
-        t.track_unstruct_event(evJson)
+        t.track_self_describing_event(evJson)
         self.assertEqual(mok_complete_payload.call_count, 1)
         completeArgsList = mok_complete_payload.call_args_list[0][0]
         self.assertEqual(len(completeArgsList), 4)
@@ -474,7 +474,7 @@ class TestTracker(unittest.TestCase):
         self.assertTrue(actualTstampArg is None)
 
     @mock.patch("snowplow_tracker.Tracker.complete_payload")
-    def test_track_unstruct_event_all_args(self, mok_complete_payload: Any) -> None:
+    def test_track_self_describing_event_all_args(self, mok_complete_payload: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
@@ -485,7 +485,7 @@ class TestTracker(unittest.TestCase):
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evContext = [ctx]
         evTstamp = 1399021242030
-        t.track_unstruct_event(evJson, evContext, evTstamp)
+        t.track_self_describing_event(evJson, evContext, evTstamp)
         self.assertEqual(mok_complete_payload.call_count, 1)
         completeArgsList = mok_complete_payload.call_args_list[0][0]
         self.assertEqual(len(completeArgsList), 4)
@@ -510,7 +510,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(actualTstampArg, evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.complete_payload")
-    def test_track_unstruct_event_encode(self, mok_complete_payload: Any) -> None:
+    def test_track_self_describing_event_encode(self, mok_complete_payload: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
@@ -518,7 +518,7 @@ class TestTracker(unittest.TestCase):
 
         t = Tracker(e, encode_base64=True)
         evJson = SelfDescribingJson("test.sde.schema", {"n": "v"})
-        t.track_unstruct_event(evJson)
+        t.track_self_describing_event(evJson)
         self.assertEqual(mok_complete_payload.call_count, 1)
         completeArgsList = mok_complete_payload.call_args_list[0][0]
         self.assertEqual(len(completeArgsList), 4)
@@ -829,7 +829,7 @@ class TestTracker(unittest.TestCase):
         }
         self.assertDictEqual(secItemCallKwargs, expectedSecItemPairs)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_link_click(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -867,7 +867,7 @@ class TestTracker(unittest.TestCase):
         self.assertIs(callArgs[1][0], ctx)
         self.assertEqual(callArgs[2], evTstamp)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_link_click_optional_none(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -891,7 +891,7 @@ class TestTracker(unittest.TestCase):
         self.assertTrue(callArgs[1] is None)
         self.assertTrue(callArgs[2] is None)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_add_to_cart(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -931,7 +931,7 @@ class TestTracker(unittest.TestCase):
         self.assertIs(callArgs[1][0], ctx)
         self.assertEqual(callArgs[2], evTstamp)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_add_to_cart_optional_none(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -953,7 +953,7 @@ class TestTracker(unittest.TestCase):
         self.assertTrue(callArgs[1] is None)
         self.assertTrue(callArgs[2] is None)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_remove_from_cart(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -993,7 +993,7 @@ class TestTracker(unittest.TestCase):
         self.assertIs(callArgs[1][0], ctx)
         self.assertEqual(callArgs[2], evTstamp)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_remove_from_cart_optional_none(
         self, mok_track_unstruct: Any
     ) -> None:
@@ -1017,7 +1017,7 @@ class TestTracker(unittest.TestCase):
         self.assertTrue(callArgs[1] is None)
         self.assertTrue(callArgs[2] is None)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_change(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -1057,7 +1057,7 @@ class TestTracker(unittest.TestCase):
         self.assertIs(callArgs[1][0], ctx)
         self.assertEqual(callArgs[2], evTstamp)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_change_optional_none(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -1083,7 +1083,7 @@ class TestTracker(unittest.TestCase):
         self.assertTrue(callArgs[1] is None)
         self.assertTrue(callArgs[2] is None)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -1125,7 +1125,7 @@ class TestTracker(unittest.TestCase):
         self.assertIs(callArgs[1][0], ctx)
         self.assertEqual(callArgs[2], evTstamp)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_invalid_element_type(
         self, mok_track_unstruct: Any
     ) -> None:
@@ -1155,7 +1155,7 @@ class TestTracker(unittest.TestCase):
                 tstamp=evTstamp,
             )
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_invalid_element_type_disabled_contracts(
         self, mok_track_unstruct: Any
     ) -> None:
@@ -1200,7 +1200,7 @@ class TestTracker(unittest.TestCase):
         self.assertIs(callArgs[1][0], ctx)
         self.assertEqual(callArgs[2], evTstamp)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_optional_none(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -1218,7 +1218,7 @@ class TestTracker(unittest.TestCase):
         self.assertTrue(callArgs[1] is None)
         self.assertTrue(callArgs[2] is None)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_empty_elems(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -1234,7 +1234,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs[0].to_json(), expected)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_site_search(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -1265,7 +1265,7 @@ class TestTracker(unittest.TestCase):
         self.assertIs(callArgs[1][0], ctx)
         self.assertEqual(callArgs[2], evTstamp)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_site_search_optional_none(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
@@ -1286,7 +1286,7 @@ class TestTracker(unittest.TestCase):
         self.assertTrue(callArgs[1] is None)
         self.assertTrue(callArgs[2] is None)
 
-    @mock.patch("snowplow_tracker.Tracker.track_unstruct_event")
+    @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_screen_view(self, mok_track_unstruct: Any) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -798,7 +798,28 @@ class Tracker:
         return self.complete_payload(pb, context, tstamp, event_subject)
 
     # Alias
-    track_self_describing_event = track_unstruct_event
+    def track_unstruct_event(
+        self,
+        event_json: SelfDescribingJson,
+        context: Optional[List[SelfDescribingJson]] = None,
+        tstamp: Optional[float] = None,
+        event_subject: Optional[_subject.Subject] = None,
+    ) -> "Tracker":
+        """
+        :param  event_json:      The properties of the event. Has two field:
+                                 A "data" field containing the event properties and
+                                 A "schema" field identifying the schema against which the data is validated
+        :type   event_json:      self_describing_json
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :param  tstamp:          Optional event timestamp in milliseconds
+        :type   tstamp:          int | float | None
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :rtype:                  tracker
+        """ 
+        warn('track_unstruct_event will be deprecated in future versions. Please use track_self_describing_event.', DeprecationWarning, stacklevel=2)
+        return self.track_self_describing_event(event_json, context, tstamp, event_subject)
 
     def flush(self, is_async: bool = False) -> "Tracker":
         """

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -22,6 +22,7 @@
 import time
 import uuid
 from typing import Any, Optional, Union, List, Dict, Sequence
+from warnings import warn
 
 from snowplow_tracker import payload, _version, SelfDescribingJson
 from snowplow_tracker import subject as _subject
@@ -310,7 +311,7 @@ class Tracker:
             "%s/link_click/%s/1-0-1" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_unstruct_event(event_json, context, tstamp, event_subject)
+        return self.track_self_describing_event(event_json, context, tstamp, event_subject)
 
     def track_add_to_cart(
         self,
@@ -363,7 +364,7 @@ class Tracker:
             "%s/add_to_cart/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_unstruct_event(event_json, context, tstamp, event_subject)
+        return self.track_self_describing_event(event_json, context, tstamp, event_subject)
 
     def track_remove_from_cart(
         self,
@@ -416,7 +417,7 @@ class Tracker:
             "%s/remove_from_cart/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_unstruct_event(event_json, context, tstamp, event_subject)
+        return self.track_self_describing_event(event_json, context, tstamp, event_subject)
 
     def track_form_change(
         self,
@@ -470,7 +471,7 @@ class Tracker:
             "%s/change_form/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_unstruct_event(event_json, context, tstamp, event_subject)
+        return self.track_self_describing_event(event_json, context, tstamp, event_subject)
 
     def track_form_submit(
         self,
@@ -511,7 +512,7 @@ class Tracker:
             "%s/submit_form/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_unstruct_event(event_json, context, tstamp, event_subject)
+        return self.track_self_describing_event(event_json, context, tstamp, event_subject)
 
     def track_site_search(
         self,
@@ -555,7 +556,7 @@ class Tracker:
             "%s/site_search/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_unstruct_event(event_json, context, tstamp, event_subject)
+        return self.track_self_describing_event(event_json, context, tstamp, event_subject)
 
     def track_ecommerce_transaction_item(
         self,
@@ -717,7 +718,7 @@ class Tracker:
             screen_view_properties,
         )
 
-        return self.track_unstruct_event(event_json, context, tstamp, event_subject)
+        return self.track_self_describing_event(event_json, context, tstamp, event_subject)
 
     def track_struct_event(
         self,
@@ -764,7 +765,7 @@ class Tracker:
 
         return self.complete_payload(pb, context, tstamp, event_subject)
 
-    def track_unstruct_event(
+    def track_self_describing_event(
         self,
         event_json: SelfDescribingJson,
         context: Optional[List[SelfDescribingJson]] = None,


### PR DESCRIPTION
This PR replaces the internal usage of track_unstruct_event with track_self_describing_event. It also adds a deprecation warning for when track_unstruct_event is called.