### PR TITLE
Refactor ScreenView using a single schema for all the trackers (#close 303)

### DIFF
--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -128,7 +128,7 @@ class IntegrationTest(unittest.TestCase):
     def test_integration_screen_view(self) -> None:
         t = tracker.Tracker([get_emitter], default_subject, encode_base64=False)
         with HTTMock(pass_response_content):
-            t.track_screen_view("Game HUD 2", id_="534")
+            t.track_screen_view("534", "Game HUD 2")
         expected_fields = {"e": "ue"}
         for key in expected_fields:
             self.assertEqual(from_querystring(key, querystrings[-1]), expected_fields[key])
@@ -137,10 +137,10 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(envelope, {
             "schema": "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0",
             "data": {
-                "schema": "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0",
+                "schema": "iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0",
                 "data": {
-                    "name": "Game HUD 2",
-                    "id": "534"
+                    "id": "534",
+                    "name": "Game HUD 2"                    
                 }
             }
         })
@@ -394,7 +394,7 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(actual_a, unicode_a)
 
         uepr_string = unquote_plus(from_querystring("ue_pr", querystrings[-1]))
-        actual_b = json.loads(uepr_string)['data']['data']['name']
+        actual_b = json.loads(uepr_string)['data']['data']['id']
         self.assertEqual(actual_b, unicode_b)
 
     def test_unicode_post(self) -> None:
@@ -413,5 +413,5 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(in_test_ctx, unicode_a)
 
         sv_event = querystrings[-1]
-        in_uepr_name = json.loads(sv_event['data'][0]['ue_pr'])['data']['data']['name']
+        in_uepr_name = json.loads(sv_event['data'][0]['ue_pr'])['data']['data']['id']
         self.assertEqual(in_uepr_name, unicode_b)

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -125,10 +125,10 @@ class IntegrationTest(unittest.TestCase):
 
         self.assertEqual(from_querystring("ttm", querystrings[-3]), from_querystring("ttm", querystrings[-2]))
 
-    def test_integration_screen_view(self) -> None:
+    def test_integration_mobile_screen_view(self) -> None:
         t = tracker.Tracker([get_emitter], default_subject, encode_base64=False)
         with HTTMock(pass_response_content):
-            t.track_screen_view("534", "Game HUD 2")
+            t.track_mobile_screen_view("534", "Game HUD 2")
         expected_fields = {"e": "ue"}
         for key in expected_fields:
             self.assertEqual(from_querystring(key, querystrings[-1]), expected_fields[key])
@@ -380,7 +380,7 @@ class IntegrationTest(unittest.TestCase):
         test_ctx = SelfDescribingJson('iglu:a.b/c/jsonschema/1-0-0', {'test': unicode_a})
         with HTTMock(pass_response_content):
             t.track_page_view(unicode_b, context=[test_ctx])
-            t.track_screen_view(unicode_b, context=[test_ctx])
+            t.track_mobile_screen_view(unicode_b, context=[test_ctx])
 
         url_string = unquote_plus(from_querystring("url", querystrings[-2]))
         try:
@@ -404,7 +404,7 @@ class IntegrationTest(unittest.TestCase):
         test_ctx = SelfDescribingJson('iglu:a.b/c/jsonschema/1-0-0', {'test': unicode_a})
         with HTTMock(pass_post_response_content):
             t.track_page_view(unicode_b, context=[test_ctx])
-            t.track_screen_view(unicode_b, context=[test_ctx])
+            t.track_mobile_screen_view(unicode_b, context=[test_ctx])
 
         pv_event = querystrings[-2]
         self.assertEqual(pv_event['data'][0]['url'], unicode_b)

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -44,6 +44,9 @@ REMOVE_FROM_CART_SCHEMA = (
 FORM_CHANGE_SCHEMA = "iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0"
 FORM_SUBMIT_SCHEMA = "iglu:com.snowplowanalytics.snowplow/submit_form/jsonschema/1-0-0"
 SITE_SEARCH_SCHEMA = "iglu:com.snowplowanalytics.snowplow/site_search/jsonschema/1-0-0"
+MOBILE_SCREEN_VIEW_SCHEMA = (
+    "iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0"
+)
 SCREEN_VIEW_SCHEMA = "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0"
 
 # helpers

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -44,7 +44,7 @@ REMOVE_FROM_CART_SCHEMA = (
 FORM_CHANGE_SCHEMA = "iglu:com.snowplowanalytics.snowplow/change_form/jsonschema/1-0-0"
 FORM_SUBMIT_SCHEMA = "iglu:com.snowplowanalytics.snowplow/submit_form/jsonschema/1-0-0"
 SITE_SEARCH_SCHEMA = "iglu:com.snowplowanalytics.snowplow/site_search/jsonschema/1-0-0"
-SCREEN_VIEW_SCHEMA = "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0"
+SCREEN_VIEW_SCHEMA = "iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0"
 
 # helpers
 _TEST_UUID = "5628c4c6-3f8a-43f8-a09f-6ff68f68dfb6"
@@ -474,7 +474,9 @@ class TestTracker(unittest.TestCase):
         self.assertTrue(actualTstampArg is None)
 
     @mock.patch("snowplow_tracker.Tracker.complete_payload")
-    def test_track_self_describing_event_all_args(self, mok_complete_payload: Any) -> None:
+    def test_track_self_describing_event_all_args(
+        self, mok_complete_payload: Any
+    ) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
@@ -510,7 +512,9 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(actualTstampArg, evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.complete_payload")
-    def test_track_self_describing_event_encode(self, mok_complete_payload: Any) -> None:
+    def test_track_self_describing_event_encode(
+        self, mok_complete_payload: Any
+    ) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
@@ -1297,7 +1301,7 @@ class TestTracker(unittest.TestCase):
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
 
-        t.track_screen_view("screenName", "screenId", context=[ctx], tstamp=evTstamp)
+        t.track_screen_view("screenId", "screenName", context=[ctx], tstamp=evTstamp)
 
         expected = {
             "schema": SCREEN_VIEW_SCHEMA,

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -720,6 +720,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 tracker
         """
+        warn(
+            "track_screen_view will be deprecated in future versions. Please use track_mobile_screen_view.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         screen_view_properties = {}
         if name is not None:
             screen_view_properties["name"] = name

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -44,6 +44,7 @@ Constants & config
 VERSION = "py-%s" % _version.__version__
 DEFAULT_ENCODE_BASE64 = True
 BASE_SCHEMA_PATH = "iglu:com.snowplowanalytics.snowplow"
+MOBILE_SCHEMA_PATH = "iglu:com.snowplowanalytics.mobile"
 SCHEMA_TAG = "jsonschema"
 CONTEXT_SCHEMA = "%s/contexts/%s/1-0-1" % (BASE_SCHEMA_PATH, SCHEMA_TAG)
 UNSTRUCT_EVENT_SCHEMA = "%s/unstruct_event/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG)
@@ -700,17 +701,32 @@ class Tracker:
 
     def track_screen_view(
         self,
+        id_: str,
         name: Optional[str] = None,
-        id_: Optional[str] = None,
+        type: Optional[str] = None,
+        previous_name: Optional[str] = None,
+        previous_id: Optional[str] = None,
+        previous_type: Optional[str] = None,
+        transition_type: Optional[str] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
     ) -> "Tracker":
         """
+        :param  id_:            Screen view ID
+        :type   id_:            string
         :param  name:           The name of the screen view event
         :type   name:           string_or_none
-        :param  id_:            Screen view ID
-        :type   id_:            string_or_none
+        :param  type:           The type of screen that was viewed e.g feed / carousel.
+        :type   type:           string | None
+        :param  previous_name:  The name of the previous screen.
+        :type   previous_name:  string | None
+        :param  previous_id:    The screenview ID of the previous screenview.
+        :type   previous_id:    string | None
+        :param  previous_type   The screen type of the previous screenview
+        :type   previous_type   string | None
+        :param  transition_type The type of transition that led to the screen being viewed.
+        :type   transition_type string | None
         :param  context:        Custom context for the event
         :type   context:        context_array | None
         :param  tstamp:         Optional event timestamp in milliseconds
@@ -720,16 +736,26 @@ class Tracker:
         :rtype:                 tracker
         """
         screen_view_properties = {}
+
+        screen_view_properties["id"] = id_
+
         if name is not None:
             screen_view_properties["name"] = name
-        if id_ is not None:
-            screen_view_properties["id"] = id_
+        if type is not None:
+            screen_view_properties["type"] = type
+        if previous_name is not None:
+            screen_view_properties["previousName"] = previous_name
+        if previous_id is not None:
+            screen_view_properties["previousId"] = previous_id
+        if previous_type is not None:
+            screen_view_properties["previousType"] = previous_type
+        if transition_type is not None:
+            screen_view_properties["transitionType"] = transition_type
 
         event_json = SelfDescribingJson(
-            "%s/screen_view/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG),
+            "%s/screen_view/%s/1-0-0" % (MOBILE_SCHEMA_PATH, SCHEMA_TAG),
             screen_view_properties,
         )
-
         return self.track_self_describing_event(
             event_json, context, tstamp, event_subject
         )

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -742,7 +742,7 @@ class Tracker:
 
     def track_mobile_screen_view(
         self,
-        id_: str,
+        id_: Optional[str] = None,
         name: Optional[str] = None,
         type: Optional[str] = None,
         previous_name: Optional[str] = None,
@@ -754,8 +754,8 @@ class Tracker:
         event_subject: Optional[_subject.Subject] = None,
     ) -> "Tracker":
         """
-        :param  id_:            Screen view ID
-        :type   id_:            string
+        :param  id_:            Screen view ID. This must be of type UUID.
+        :type   id_:            string | None
         :param  name:           The name of the screen view event
         :type   name:           string_or_none
         :param  type:           The type of screen that was viewed e.g feed / carousel.
@@ -777,6 +777,9 @@ class Tracker:
         :rtype:                 tracker
         """
         screen_view_properties = {}
+
+        if id_ is None:
+            id_ = self.get_uuid()
 
         screen_view_properties["id"] = id_
 

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -701,6 +701,42 @@ class Tracker:
 
     def track_screen_view(
         self,
+        name: Optional[str] = None,
+        id_: Optional[str] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
+        tstamp: Optional[float] = None,
+        event_subject: Optional[_subject.Subject] = None,
+    ) -> "Tracker":
+        """
+        :param  name:           The name of the screen view event
+        :type   name:           string_or_none
+        :param  id_:            Screen view ID
+        :type   id_:            string_or_none
+        :param  context:        Custom context for the event
+        :type   context:        context_array | None
+        :param  tstamp:         Optional event timestamp in milliseconds
+        :type   tstamp:         int | float | None
+        :param  event_subject:  Optional per event subject
+        :type   event_subject:  subject | None
+        :rtype:                 tracker
+        """
+        screen_view_properties = {}
+        if name is not None:
+            screen_view_properties["name"] = name
+        if id_ is not None:
+            screen_view_properties["id"] = id_
+
+        event_json = SelfDescribingJson(
+            "%s/screen_view/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG),
+            screen_view_properties,
+        )
+
+        return self.track_self_describing_event(
+            event_json, context, tstamp, event_subject
+        )
+
+    def track_mobile_screen_view(
+        self,
         id_: str,
         name: Optional[str] = None,
         type: Optional[str] = None,


### PR DESCRIPTION
This PR updates the track_screen_view() function to use the new mobile schema in line with other trackers. 