### PR TITLE
Issue/315 deprecation warnings

### DIFF
--- a/snowplow_tracker/celery/celery_emitter.py
+++ b/snowplow_tracker/celery/celery_emitter.py
@@ -17,6 +17,7 @@
 
 import logging
 from typing import Any, Optional
+from warnings import warn
 
 from snowplow_tracker.emitters import Emitter
 from snowplow_tracker.typing import HttpProtocol, Method
@@ -41,7 +42,6 @@ class CeleryEmitter(Emitter):
     """
 
     if _CELERY_OPT:
-
         celery_app = None
 
         def __init__(
@@ -53,6 +53,11 @@ class CeleryEmitter(Emitter):
             batch_size: Optional[int] = None,
             byte_limit: Optional[int] = None,
         ) -> None:
+            warn(
+                "The Celery Emitter will be deprecated in future versions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             super(CeleryEmitter, self).__init__(
                 endpoint, protocol, port, method, batch_size, None, None, byte_limit
             )

--- a/snowplow_tracker/redis/redis_emitter.py
+++ b/snowplow_tracker/redis/redis_emitter.py
@@ -18,6 +18,7 @@
 import json
 import logging
 from typing import Any, Optional
+from warnings import warn
 from snowplow_tracker.typing import PayloadDict, RedisProtocol
 
 _REDIS_OPT = True
@@ -48,6 +49,11 @@ class RedisEmitter(object):
             :param key:  The Redis key for the list of events
             :type  key:  string
             """
+            warn(
+                "The Redis Emitter will be deprecated in future versions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             if rdb is None:
                 rdb = redis.StrictRedis()
 

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -345,6 +345,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 tracker
         """
+        warn(
+            "track_add_to_cart will be deprecated in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(sku)
 
         properties = {}
@@ -400,6 +405,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 tracker
         """
+        warn(
+            "track_remove_from_cart will be deprecated in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(sku)
 
         properties = {}
@@ -606,6 +616,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:              tracker
         """
+        warn(
+            "track_ecommerce_transaction_item will be deprecated in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(order_id)
         non_empty_string(sku)
 
@@ -666,6 +681,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 tracker
         """
+        warn(
+            "track_ecommerce_transaction will be deprecated in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(order_id)
 
         pb = payload.Payload()


### PR DESCRIPTION
This PR adds deprecation warnings for the Redis and Celery Emitters as well as the eCommerce events that will be deprecated in V1 of the Python tracker.