### PR TITLE
EventStore object not parsed in Snowplow Emitter Configuration (close #320)

### DIFF
--- a/snowplow_tracker/snowplow.py
+++ b/snowplow_tracker/snowplow.py
@@ -80,6 +80,7 @@ class Snowplow:
             byte_limit=emitter_config.byte_limit,
             request_timeout=emitter_config.request_timeout,
             custom_retry_codes=emitter_config.custom_retry_codes,
+            event_store=emitter_config.event_store,
         )
 
         tracker = Tracker(


### PR DESCRIPTION
This PR fixes an issue that meant the event store could not be set via the snowplow interface emitter configuration