### PR TITLE
Release/0.14.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
 
     - name: Get tag and tracker versions
       id: version
@@ -40,10 +40,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -57,7 +57,7 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: distfiles_${{ github.run_id }}
         path: dist
@@ -68,15 +68,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 
     - name: Download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: distfiles_${{ github.run_id }}
         path: ${{ github.workspace }}/dist
@@ -100,7 +100,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: snyk/actions/setup@master
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+Version 0.14.0 (2023-03-21)
+---------------------------
+Adds deprecation warnings for V1 changes (#315)
+Update GH actions to use Node16 (#317)
+Adds event store parameter to Snowplow interface (#320)
+Adds missing parameters to async emitter (#323)
+
 Version 0.13.0 (2023-01-24)
 ---------------------------
 Adds Snowplow Interface (#295)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ copyright = "2023, Alex Dean, Paul Boocock, Matus Tomlein, Jack Keene"
 author = 'Alex Dean, Paul Boocock, Matus Tomlein, Jack Keene'
 
 # The full version, including alpha/beta/rc tags
-release = "0.13"
+release = "0.14"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ authors_email_str = ", ".join(authors_email_list)
 
 setup(
     name="snowplow-tracker",
-    version="0.13.0",
+    version="0.14.0",
     author=authors_str,
     author_email=authors_email_str,
     packages=[

--- a/snowplow_tracker/_version.py
+++ b/snowplow_tracker/_version.py
@@ -15,6 +15,6 @@
 #     language governing permissions and limitations there under.
 # """
 
-__version_info__ = (0, 13, 0)
+__version_info__ = (0, 14, 0)
 __version__ = ".".join(str(x) for x in __version_info__)
 __build_version__ = __version__ + ""

--- a/snowplow_tracker/celery/celery_emitter.py
+++ b/snowplow_tracker/celery/celery_emitter.py
@@ -17,6 +17,7 @@
 
 import logging
 from typing import Any, Optional
+from warnings import warn
 
 from snowplow_tracker.emitters import Emitter
 from snowplow_tracker.typing import HttpProtocol, Method
@@ -41,7 +42,6 @@ class CeleryEmitter(Emitter):
     """
 
     if _CELERY_OPT:
-
         celery_app = None
 
         def __init__(
@@ -53,6 +53,11 @@ class CeleryEmitter(Emitter):
             batch_size: Optional[int] = None,
             byte_limit: Optional[int] = None,
         ) -> None:
+            warn(
+                "The Celery Emitter will be deprecated in future versions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             super(CeleryEmitter, self).__init__(
                 endpoint, protocol, port, method, batch_size, None, None, byte_limit
             )

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -439,8 +439,10 @@ class AsyncEmitter(Emitter):
         on_failure: Optional[FailureCallback] = None,
         thread_count: int = 1,
         byte_limit: Optional[int] = None,
+        request_timeout: Optional[Union[float, Tuple[float, float]]] = None,
         max_retry_delay_seconds: int = 60,
         buffer_capacity: int = None,
+        custom_retry_codes: Dict[int, bool] = {},
         event_store: Optional[EventStore] = None,
     ) -> None:
         """
@@ -476,17 +478,19 @@ class AsyncEmitter(Emitter):
         :type   event_store:    EventStore
         """
         super(AsyncEmitter, self).__init__(
-            endpoint,
-            protocol,
-            port,
-            method,
-            batch_size,
-            on_success,
-            on_failure,
-            byte_limit,
-            max_retry_delay_seconds,
-            buffer_capacity,
-            event_store,
+            endpoint=endpoint,
+            protocol=protocol,
+            port=port,
+            method=method,
+            batch_size=batch_size,
+            on_success=on_success,
+            on_failure=on_failure,
+            byte_limit=byte_limit,
+            request_timeout=request_timeout,
+            max_retry_delay_seconds=max_retry_delay_seconds,
+            buffer_capacity=buffer_capacity,
+            custom_retry_codes=custom_retry_codes,
+            event_store=event_store,
         )
         self.queue = Queue()
         for i in range(thread_count):

--- a/snowplow_tracker/redis/redis_emitter.py
+++ b/snowplow_tracker/redis/redis_emitter.py
@@ -18,6 +18,7 @@
 import json
 import logging
 from typing import Any, Optional
+from warnings import warn
 from snowplow_tracker.typing import PayloadDict, RedisProtocol
 
 _REDIS_OPT = True
@@ -48,6 +49,11 @@ class RedisEmitter(object):
             :param key:  The Redis key for the list of events
             :type  key:  string
             """
+            warn(
+                "The Redis Emitter will be deprecated in future versions.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             if rdb is None:
                 rdb = redis.StrictRedis()
 

--- a/snowplow_tracker/snowplow.py
+++ b/snowplow_tracker/snowplow.py
@@ -80,6 +80,7 @@ class Snowplow:
             byte_limit=emitter_config.byte_limit,
             request_timeout=emitter_config.request_timeout,
             custom_retry_codes=emitter_config.custom_retry_codes,
+            event_store=emitter_config.event_store,
         )
 
         tracker = Tracker(

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -345,6 +345,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 tracker
         """
+        warn(
+            "track_add_to_cart will be deprecated in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(sku)
 
         properties = {}
@@ -400,6 +405,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 tracker
         """
+        warn(
+            "track_remove_from_cart will be deprecated in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(sku)
 
         properties = {}
@@ -606,6 +616,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:              tracker
         """
+        warn(
+            "track_ecommerce_transaction_item will be deprecated in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(order_id)
         non_empty_string(sku)
 
@@ -666,6 +681,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 tracker
         """
+        warn(
+            "track_ecommerce_transaction will be deprecated in future versions.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(order_id)
 
         pb = payload.Payload()


### PR DESCRIPTION
This is a minor release that fixes some minor bugs in the Snowplow interface and async emitter. It also updates the Node version used in the Github Actions and adds deprecation warnings for the upcoming V1 release.

**CHANGELOG**
**Bug fixes:**
Adds event store parameter to Snowplow interface (#320)
Adds missing parameters to async emitter (#323)

**Under the hood:**
Update GH actions to use Node16 (#317)
Adds deprecation warnings for V1 changes (#315)

