### PR TITLE
Use Requests session for sending events (close #221)

### DIFF
--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -156,6 +156,11 @@ class Emitter(object):
         self.custom_retry_codes = custom_retry_codes
         logger.info("Emitter initialized with endpoint " + self.endpoint)
 
+        if session is None:
+            session = requests.Session()
+
+        self.session = session
+
     @staticmethod
     def as_collector_uri(
         endpoint: str,

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -69,6 +69,7 @@ class Emitter(object):
         buffer_capacity: Optional[int] = None,
         custom_retry_codes: Dict[int, bool] = {},
         event_store: Optional[EventStore] = None,
+        session: requests.Session = None,
     ) -> None:
         """
         :param endpoint:    The collector URL. If protocol is not set in endpoint it will automatically set to "https://" - this is done automatically.
@@ -107,6 +108,8 @@ class Emitter(object):
         :type   custom_retry_codes: dict
         :param  event_store:    Stores the event buffer and buffer capacity. Default is an InMemoryEventStore object with buffer_capacity of 10,000 events.
         :type   event_store:    EventStore | None
+        :param  session:    Persist parameters across requests by using a session object
+        :type   session:    request.Session
         """
         one_of(protocol, PROTOCOLS)
         one_of(method, METHODS)

--- a/snowplow_tracker/emitters.py
+++ b/snowplow_tracker/emitters.py
@@ -251,7 +251,7 @@ class Emitter(object):
         logger.info("Sending POST request to %s..." % self.endpoint)
         logger.debug("Payload: %s" % data)
         try:
-            r = requests.post(
+            r = self.session.post(
                 self.endpoint,
                 data=data,
                 headers={"Content-Type": "application/json; charset=utf-8"},
@@ -271,7 +271,7 @@ class Emitter(object):
         logger.info("Sending GET request to %s..." % self.endpoint)
         logger.debug("Payload: %s" % payload)
         try:
-            r = requests.get(
+            r = self.session.get(
                 self.endpoint, params=payload, timeout=self.request_timeout
             )
         except requests.RequestException as e:


### PR DESCRIPTION
This PR adds the ability for users to parse in a session object to the emitter, increasing efficiency of the tracker under heavy usage by pooling connections.