### PR TITLE
Make tracker namespace mandatory (close #337)

### DIFF
--- a/examples/redis_example/redis_app.py
+++ b/examples/redis_example/redis_app.py
@@ -49,7 +49,7 @@ class RedisEmitter(object):
 def main():
     emitter = RedisEmitter()
 
-    t = Tracker(emitter)
+    t = Tracker("snowplow_tracker", emitter)
 
     t.track_page_view("https://www.snowplow.io", "Homepage")
     t.track_page_ping("https://www.snowplow.io", "Homepage")

--- a/examples/redis_example/redis_app.py
+++ b/examples/redis_example/redis_app.py
@@ -49,7 +49,7 @@ class RedisEmitter(object):
 def main():
     emitter = RedisEmitter()
 
-    t = Tracker("snowplow_tracker", emitter)
+    t = Tracker(namespace="snowplow_tracker", emitters=emitter)
 
     t.track_page_view("https://www.snowplow.io", "Homepage")
     t.track_page_ping("https://www.snowplow.io", "Homepage")

--- a/examples/tracker_api_example/app.py
+++ b/examples/tracker_api_example/app.py
@@ -22,7 +22,7 @@ def main():
     s = Subject().set_platform("pc")
     s.set_lang("en").set_user_id("test_user")
 
-    t = Tracker("snowplow_tracker", e, s)
+    t = Tracker(namespace="snowplow_tracker", emitters=e, subject=s)
 
     print("Sending events to " + e.endpoint)
 

--- a/examples/tracker_api_example/app.py
+++ b/examples/tracker_api_example/app.py
@@ -22,7 +22,7 @@ def main():
     s = Subject().set_platform("pc")
     s.set_lang("en").set_user_id("test_user")
 
-    t = Tracker(e, s)
+    t = Tracker("snowplow_tracker", e, s)
 
     print("Sending events to " + e.endpoint)
 

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -64,7 +64,7 @@ def fail_response_content(url: str, request: Any) -> Dict[str, Any]:
 
 class IntegrationTest(unittest.TestCase):
     def test_integration_page_view(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject)
+        t = tracker.Tracker("namespace", [get_emitter], default_subject)
         with HTTMock(pass_response_content):
             t.track_page_view(
                 "http://savethearctic.org", "Save The Arctic", "http://referrer.com"
@@ -81,7 +81,7 @@ class IntegrationTest(unittest.TestCase):
             )
 
     def test_integration_ecommerce_transaction_item(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject)
+        t = tracker.Tracker("namespace", [get_emitter], default_subject)
         with HTTMock(pass_response_content):
             t.track_ecommerce_transaction_item(
                 "12345", "pbz0025", 7.99, 2, "black-tarot", "tarot", currency="GBP"
@@ -102,7 +102,7 @@ class IntegrationTest(unittest.TestCase):
             )
 
     def test_integration_ecommerce_transaction(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject)
+        t = tracker.Tracker("namespace", [get_emitter], default_subject)
         with HTTMock(pass_response_content):
             t.track_ecommerce_transaction(
                 "6a8078be",
@@ -157,7 +157,9 @@ class IntegrationTest(unittest.TestCase):
         )
 
     def test_integration_mobile_screen_view(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject, encode_base64=False)
+        t = tracker.Tracker(
+            "namespace", [get_emitter], default_subject, encode_base64=False
+        )
         with HTTMock(pass_response_content):
             t.track_mobile_screen_view("534", "Game HUD 2")
         expected_fields = {"e": "ue"}
@@ -179,7 +181,7 @@ class IntegrationTest(unittest.TestCase):
         )
 
     def test_integration_struct_event(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject)
+        t = tracker.Tracker("namespace", [get_emitter], default_subject)
         with HTTMock(pass_response_content):
             t.track_struct_event(
                 "Ecomm", "add-to-basket", "dog-skateboarding-video", "hd", 13.99
@@ -198,7 +200,9 @@ class IntegrationTest(unittest.TestCase):
             )
 
     def test_integration_self_describing_event_non_base64(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject, encode_base64=False)
+        t = tracker.Tracker(
+            "namespace", [get_emitter], default_subject, encode_base64=False
+        )
         with HTTMock(pass_response_content):
             t.track_self_describing_event(
                 SelfDescribingJson(
@@ -229,7 +233,9 @@ class IntegrationTest(unittest.TestCase):
         )
 
     def test_integration_self_describing_event_base64(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject, encode_base64=True)
+        t = tracker.Tracker(
+            "namespace", [get_emitter], default_subject, encode_base64=True
+        )
         with HTTMock(pass_response_content):
             t.track_self_describing_event(
                 SelfDescribingJson(
@@ -264,7 +270,9 @@ class IntegrationTest(unittest.TestCase):
         )
 
     def test_integration_context_non_base64(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject, encode_base64=False)
+        t = tracker.Tracker(
+            "namespace", [get_emitter], default_subject, encode_base64=False
+        )
         with HTTMock(pass_response_content):
             t.track_page_view(
                 "localhost",
@@ -293,7 +301,9 @@ class IntegrationTest(unittest.TestCase):
         )
 
     def test_integration_context_base64(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject, encode_base64=True)
+        t = tracker.Tracker(
+            "namespace", [get_emitter], default_subject, encode_base64=True
+        )
         with HTTMock(pass_response_content):
             t.track_page_view(
                 "localhost",
@@ -335,9 +345,9 @@ class IntegrationTest(unittest.TestCase):
         s.set_lang("en")
 
         t = tracker.Tracker(
+            "cf",
             [emitters.Emitter("localhost", method="get")],
             s,
-            "cf",
             app_id="angry-birds-android",
         )
         with HTTMock(pass_response_content):
@@ -371,9 +381,9 @@ class IntegrationTest(unittest.TestCase):
         s.set_network_user_id("fbc6c76c-bce5-43ce-8d5a-31c5")
 
         t = tracker.Tracker(
+            "cf",
             [emitters.Emitter("localhost", method="get")],
             s,
-            "cf",
             app_id="angry-birds-android",
         )
         with HTTMock(pass_response_content):
@@ -397,9 +407,9 @@ class IntegrationTest(unittest.TestCase):
         s.set_lang("ES")
 
         t = tracker.Tracker(
+            "namespace",
             [emitters.Emitter("localhost", method="get")],
             s,
-            "cf",
             app_id="angry-birds-android",
         )
         evSubject = (
@@ -422,7 +432,7 @@ class IntegrationTest(unittest.TestCase):
             on_success=lambda x: callback_success_queue.append(x),
             on_failure=lambda x, y: callback_failure_queue.append(x),
         )
-        t = tracker.Tracker([callback_emitter], default_subject)
+        t = tracker.Tracker("namespace", [callback_emitter], default_subject)
         with HTTMock(pass_response_content):
             t.track_page_view("http://www.example.com")
         expected = {
@@ -443,14 +453,14 @@ class IntegrationTest(unittest.TestCase):
             on_success=lambda x: callback_success_queue.append(x),
             on_failure=lambda x, y: callback_failure_queue.append(x),
         )
-        t = tracker.Tracker([callback_emitter], default_subject)
+        t = tracker.Tracker("namespace", [callback_emitter], default_subject)
         with HTTMock(fail_response_content):
             t.track_page_view("http://www.example.com")
         self.assertEqual(callback_success_queue, [])
         self.assertEqual(callback_failure_queue[0], 0)
 
     def test_post_page_view(self) -> None:
-        t = tracker.Tracker([default_emitter], default_subject)
+        t = tracker.Tracker("namespace", [default_emitter], default_subject)
         with HTTMock(pass_post_response_content):
             t.track_page_view("localhost", "local host", None)
         expected_fields = {"e": "pv", "page": "local host", "url": "localhost"}
@@ -466,7 +476,7 @@ class IntegrationTest(unittest.TestCase):
         default_emitter = emitters.Emitter(
             "localhost", protocol="http", port=80, batch_size=2
         )
-        t = tracker.Tracker(default_emitter, default_subject)
+        t = tracker.Tracker("namespace", default_emitter, default_subject)
         with HTTMock(pass_post_response_content):
             t.track_struct_event("Test", "A")
             t.track_struct_event("Test", "B")
@@ -476,7 +486,7 @@ class IntegrationTest(unittest.TestCase):
     @freeze_time("2021-04-19 00:00:01")  # unix: 1618790401000
     def test_timestamps(self) -> None:
         emitter = emitters.Emitter("localhost", protocol="http", port=80, batch_size=3)
-        t = tracker.Tracker([emitter], default_subject)
+        t = tracker.Tracker("namespace", [emitter], default_subject)
         with HTTMock(pass_post_response_content):
             t.track_page_view("localhost", "stamp0", None, tstamp=None)
             t.track_page_view("localhost", "stamp1", None, tstamp=1358933694000)
@@ -502,19 +512,21 @@ class IntegrationTest(unittest.TestCase):
 
     def test_bytelimit(self) -> None:
         default_emitter = emitters.Emitter(
-            "localhost", protocol="http", port=80, batch_size=5, byte_limit=420
+            "localhost", protocol="http", port=80, batch_size=5, byte_limit=483
         )
-        t = tracker.Tracker(default_emitter, default_subject)
+        t = tracker.Tracker("namespace", default_emitter, default_subject)
         with HTTMock(pass_post_response_content):
-            t.track_struct_event("Test", "A")  # 140 bytes
-            t.track_struct_event("Test", "A")  # 280 bytes
-            t.track_struct_event("Test", "A")  # 420 bytes. Send
-            t.track_struct_event("Test", "AA")  # 141
+            t.track_struct_event("Test", "A")  # 161 bytes
+            t.track_struct_event("Test", "A")  # 322 bytes
+            t.track_struct_event("Test", "A")  # 483 bytes. Send
+            t.track_struct_event("Test", "AA")  # 162
         self.assertEqual(len(querystrings[-1]["data"]), 3)
-        self.assertEqual(default_emitter.bytes_queued, 136 + len(_version.__version__))
+        self.assertEqual(default_emitter.bytes_queued, 156 + len(_version.__version__))
 
     def test_unicode_get(self) -> None:
-        t = tracker.Tracker([get_emitter], default_subject, encode_base64=False)
+        t = tracker.Tracker(
+            "namespace", [get_emitter], default_subject, encode_base64=False
+        )
         unicode_a = "\u0107"
         unicode_b = "test.\u0107om"
         test_ctx = SelfDescribingJson(
@@ -540,7 +552,9 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(actual_b, unicode_b)
 
     def test_unicode_post(self) -> None:
-        t = tracker.Tracker([default_emitter], default_subject, encode_base64=False)
+        t = tracker.Tracker(
+            "namespace", [default_emitter], default_subject, encode_base64=False
+        )
         unicode_a = "\u0107"
         unicode_b = "test.\u0107om"
         test_ctx = SelfDescribingJson(

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -96,7 +96,7 @@ class TestTracker(unittest.TestCase):
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
-        t = Tracker([e], namespace="cloudfront", encode_base64=False, app_id="AF003")
+        t = Tracker("cloudfront", [e], encode_base64=False, app_id="AF003")
         self.assertEqual(t.standard_nv_pairs["tna"], "cloudfront")
         self.assertEqual(t.standard_nv_pairs["aid"], "AF003")
         self.assertEqual(t.encode_base64, False)
@@ -105,9 +105,8 @@ class TestTracker(unittest.TestCase):
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         self.assertEqual(t.emitters, [e])
-        self.assertTrue(t.standard_nv_pairs["tna"] is None)
         self.assertTrue(t.standard_nv_pairs["aid"] is None)
         self.assertEqual(t.encode_base64, True)
 
@@ -116,19 +115,19 @@ class TestTracker(unittest.TestCase):
         e1 = mokEmitter()
         e2 = mokEmitter()
 
-        t = Tracker([e1, e2])
+        t = Tracker("namespace", [e1, e2])
         self.assertEqual(t.emitters, [e1, e2])
 
     def test_initialisation_error(self) -> None:
         with self.assertRaises(ValueError):
-            Tracker([])
+            Tracker("namespace", [])
 
     def test_initialization_with_subject(self) -> None:
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
         s = Subject()
-        t = Tracker(e, subject=s)
+        t = Tracker("namespace", e, subject=s)
         self.assertIs(t.subject, s)
 
     def test_get_uuid(self) -> None:
@@ -163,7 +162,7 @@ class TestTracker(unittest.TestCase):
         e = mokEmitter()
 
         mok_track.side_effect = mocked_track
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         evJson = SelfDescribingJson("test.schema", {"n": "v"})
         # call the alias
         t.track_self_describing_event(evJson)
@@ -174,7 +173,7 @@ class TestTracker(unittest.TestCase):
         e1 = mokEmitter()
         e2 = mokEmitter()
 
-        t = Tracker([e1, e2])
+        t = Tracker("namespace", [e1, e2])
         t.flush()
         e1.flush.assert_not_called()
         self.assertEqual(e1.sync_flush.call_count, 1)
@@ -186,7 +185,7 @@ class TestTracker(unittest.TestCase):
         e1 = mokEmitter()
         e2 = mokEmitter()
 
-        t = Tracker([e1, e2])
+        t = Tracker("namespace", [e1, e2])
         t.flush(is_async=True)
         self.assertEqual(e1.flush.call_count, 1)
         e1.sync_flush.assert_not_called()
@@ -197,7 +196,7 @@ class TestTracker(unittest.TestCase):
         mokEmitter = self.create_patch("snowplow_tracker.Emitter")
         e = mokEmitter()
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         new_subject = Subject()
         self.assertIsNot(t.subject, new_subject)
         t.set_subject(new_subject)
@@ -208,7 +207,7 @@ class TestTracker(unittest.TestCase):
         e1 = mokEmitter()
         e2 = mokEmitter()
 
-        t = Tracker(e1)
+        t = Tracker("namespace", e1)
         t.add_emitter(e2)
         self.assertEqual(t.emitters, [e1, e2])
 
@@ -222,7 +221,7 @@ class TestTracker(unittest.TestCase):
         e2 = mokEmitter()
         e3 = mokEmitter()
 
-        t = Tracker([e1, e2, e3])
+        t = Tracker("namespace", [e1, e2, e3])
 
         p = Payload({"test": "track"})
         t.track(p)
@@ -241,7 +240,7 @@ class TestTracker(unittest.TestCase):
         mok_uuid.side_effect = mocked_uuid
         mok_track.side_effect = mocked_track
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         p = Payload()
         t.complete_payload(p, None, None, None)
 
@@ -255,6 +254,7 @@ class TestTracker(unittest.TestCase):
             "dtm": 1618790401000,
             "tv": TRACKER_VERSION,
             "p": "pc",
+            "tna": "namespace",
         }
         self.assertDictEqual(passed_nv_pairs, expected)
 
@@ -268,7 +268,7 @@ class TestTracker(unittest.TestCase):
         mok_uuid.side_effect = mocked_uuid
         mok_track.side_effect = mocked_track
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         p = Payload()
         time_in_millis = 100010001000
         t.complete_payload(p, None, time_in_millis, None)
@@ -279,6 +279,7 @@ class TestTracker(unittest.TestCase):
         passed_nv_pairs = trackArgsTuple[0].nv_pairs
 
         expected = {
+            "tna": "namespace",
             "eid": _TEST_UUID,
             "dtm": 1618790401000,
             "ttm": time_in_millis,
@@ -297,7 +298,7 @@ class TestTracker(unittest.TestCase):
         mok_uuid.side_effect = mocked_uuid
         mok_track.side_effect = mocked_track
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         p = Payload()
         time_in_millis = 100010001000
         t.complete_payload(p, None, time_in_millis, None)
@@ -308,6 +309,7 @@ class TestTracker(unittest.TestCase):
         passed_nv_pairs = trackArgsTuple[0].nv_pairs
 
         expected = {
+            "tna": "namespace",
             "eid": _TEST_UUID,
             "dtm": 1618790401000,
             "ttm": time_in_millis,
@@ -326,7 +328,7 @@ class TestTracker(unittest.TestCase):
         mok_uuid.side_effect = mocked_uuid
         mok_track.side_effect = mocked_track
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         p = Payload()
         time_in_millis = 100010001000
         t.complete_payload(p, None, time_in_millis, None)
@@ -337,6 +339,7 @@ class TestTracker(unittest.TestCase):
         passed_nv_pairs = trackArgsTuple[0].nv_pairs
 
         expected = {
+            "tna": "namespace",
             "eid": _TEST_UUID,
             "dtm": 1618790401000,
             "ttm": time_in_millis,
@@ -355,7 +358,7 @@ class TestTracker(unittest.TestCase):
         mok_uuid.side_effect = mocked_uuid
         mok_track.side_effect = mocked_track
 
-        t = Tracker(e, encode_base64=False)
+        t = Tracker("namespace", e, encode_base64=False)
         p = Payload()
 
         geo_ctx = SelfDescribingJson(geoSchema, geoData)
@@ -388,7 +391,7 @@ class TestTracker(unittest.TestCase):
         mok_uuid.side_effect = mocked_uuid
         mok_track.side_effect = mocked_track
 
-        t = Tracker(e, encode_base64=True)
+        t = Tracker("namespace", e, encode_base64=True)
         p = Payload()
 
         geo_ctx = SelfDescribingJson(geoSchema, geoData)
@@ -415,7 +418,7 @@ class TestTracker(unittest.TestCase):
         mok_uuid.side_effect = mocked_uuid
         mok_track.side_effect = mocked_track
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         p = Payload()
         evSubject = Subject().set_lang("EN").set_user_id("tester")
         t.complete_payload(p, None, None, evSubject)
@@ -426,6 +429,7 @@ class TestTracker(unittest.TestCase):
         passed_nv_pairs = trackArgsTuple[0].nv_pairs
 
         expected = {
+            "tna": "namespace",
             "eid": _TEST_UUID,
             "dtm": 1618790401000,
             "tv": TRACKER_VERSION,
@@ -446,7 +450,7 @@ class TestTracker(unittest.TestCase):
 
         mok_complete_payload.side_effect = mocked_complete_payload
 
-        t = Tracker(e, encode_base64=False)
+        t = Tracker("namespace", e, encode_base64=False)
         evJson = SelfDescribingJson("test.sde.schema", {"n": "v"})
         t.track_self_describing_event(evJson)
         self.assertEqual(mok_complete_payload.call_count, 1)
@@ -481,7 +485,7 @@ class TestTracker(unittest.TestCase):
 
         mok_complete_payload.side_effect = mocked_complete_payload
 
-        t = Tracker(e, encode_base64=False)
+        t = Tracker("namespace", e, encode_base64=False)
         evJson = SelfDescribingJson("test.schema", {"n": "v"})
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evContext = [ctx]
@@ -519,7 +523,7 @@ class TestTracker(unittest.TestCase):
 
         mok_complete_payload.side_effect = mocked_complete_payload
 
-        t = Tracker(e, encode_base64=True)
+        t = Tracker("namespace", e, encode_base64=True)
         evJson = SelfDescribingJson("test.sde.schema", {"n": "v"})
         t.track_self_describing_event(evJson)
         self.assertEqual(mok_complete_payload.call_count, 1)
@@ -537,7 +541,7 @@ class TestTracker(unittest.TestCase):
 
         mok_complete_payload.side_effect = mocked_complete_payload
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         t.track_struct_event(
@@ -577,7 +581,7 @@ class TestTracker(unittest.TestCase):
 
         mok_complete_payload.side_effect = mocked_complete_payload
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         t.track_page_view(
@@ -609,7 +613,7 @@ class TestTracker(unittest.TestCase):
 
         mok_complete_payload.side_effect = mocked_complete_payload
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         t.track_page_ping(
@@ -653,7 +657,7 @@ class TestTracker(unittest.TestCase):
 
         mok_complete_payload.side_effect = mocked_complete_payload
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         t.track_ecommerce_transaction_item(
@@ -699,7 +703,7 @@ class TestTracker(unittest.TestCase):
 
         mok_complete_payload.side_effect = mocked_complete_payload
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         t.track_ecommerce_transaction(
@@ -750,7 +754,7 @@ class TestTracker(unittest.TestCase):
         mok_complete_payload.side_effect = mocked_complete_payload
         mok_track_trans_item.side_effect = mocked_track_trans_item
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         transItems = [
@@ -839,7 +843,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
 
@@ -877,7 +881,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
 
         t.track_link_click("example.com")
 
@@ -901,7 +905,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
 
@@ -941,7 +945,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
 
         t.track_add_to_cart("sku1234", 1)
 
@@ -963,7 +967,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
 
@@ -1005,7 +1009,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
 
         t.track_remove_from_cart("sku1234", 1)
 
@@ -1027,7 +1031,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
 
@@ -1067,7 +1071,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         t.track_form_change("testFormId", "testElemId", "INPUT", "testValue")
 
         expected = {
@@ -1093,7 +1097,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         elems = [
@@ -1137,7 +1141,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         elems = [
@@ -1167,7 +1171,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
         elems = [
@@ -1210,7 +1214,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         t.track_form_submit("testFormId")
 
         expected = {"schema": FORM_SUBMIT_SCHEMA, "data": {"formId": "testFormId"}}
@@ -1228,7 +1232,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         t.track_form_submit("testFormId", elements=[])
 
         expected = {"schema": FORM_SUBMIT_SCHEMA, "data": {"formId": "testFormId"}}
@@ -1244,7 +1248,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
 
@@ -1275,7 +1279,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         t.track_site_search(["track", "search"])
 
         expected = {
@@ -1296,7 +1300,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
 
@@ -1322,7 +1326,7 @@ class TestTracker(unittest.TestCase):
 
         mok_track_unstruct.side_effect = mocked_track_unstruct
 
-        t = Tracker(e)
+        t = Tracker("namespace", e)
         ctx = SelfDescribingJson("test.context.schema", {"user": "tester"})
         evTstamp = 1399021242030
 

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -966,5 +966,5 @@ class Tracker:
         self.emitters.append(emitter)
         return self
 
-    def get_namespace(self):
+    def get_namespace(self) -> str:
         return self.standard_nv_pairs["tna"]

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -54,20 +54,20 @@ Tracker class
 class Tracker:
     def __init__(
         self,
+        namespace: str,
         emitters: Union[List[EmitterProtocol], EmitterProtocol],
         subject: Optional[_subject.Subject] = None,
-        namespace: Optional[str] = None,
         app_id: Optional[str] = None,
         encode_base64: bool = DEFAULT_ENCODE_BASE64,
         json_encoder: Optional[JsonEncoderFunction] = None,
     ) -> None:
         """
+        :param namespace:        Identifier for the Tracker instance
+        :type  namespace:        string
         :param emitters:         Emitters to which events will be sent
         :type  emitters:         list[>0](emitter) | emitter
         :param subject:          Subject to be tracked
         :type  subject:          subject | None
-        :param namespace:        Identifier for the Tracker instance
-        :type  namespace:        string_or_none
         :param app_id:           Application ID
         :type  app_id:           string_or_none
         :param encode_base64:    Whether JSONs in the payload should be base-64 encoded


### PR DESCRIPTION
This PR makes the namespace parameter mandatory in the tracker initialisation. It also updates the unit and integration tests to account for the changes.