### PR TITLE
Track function to return event_id (close #338)

### DIFF
--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -223,12 +223,12 @@ class TestTracker(unittest.TestCase):
 
         t = Tracker("namespace", [e1, e2, e3])
 
-        p = Payload({"test": "track"})
+        p = Payload({"eid":"event_id"})
         t.track(p)
 
-        e1.input.assert_called_once_with({"test": "track"})
-        e2.input.assert_called_once_with({"test": "track"})
-        e3.input.assert_called_once_with({"test": "track"})
+        e1.input.assert_called_once_with({"eid":"event_id"})
+        e2.input.assert_called_once_with({"eid":"event_id"})
+        e3.input.assert_called_once_with({"eid":"event_id"})
 
     @freeze_time("2021-04-19 00:00:01")  # unix: 1618790401000
     @mock.patch("snowplow_tracker.Tracker.track")

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -224,13 +224,13 @@ class TestTracker(unittest.TestCase):
         t = Tracker("namespace", [e1, e2, e3])
 
         p = Payload({"eid": "event_id"})
-        tracker = t.track(p)
+        event_id = t.track(p)
 
         e1.input.assert_called_once_with({"eid": "event_id"})
         e2.input.assert_called_once_with({"eid": "event_id"})
         e3.input.assert_called_once_with({"eid": "event_id"})
 
-        self.assertEqual(tracker, "event_id")
+        self.assertEqual(event_id, "event_id")
 
     @freeze_time("2021-04-19 00:00:01")  # unix: 1618790401000
     @mock.patch("snowplow_tracker.Tracker.track")

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -223,12 +223,14 @@ class TestTracker(unittest.TestCase):
 
         t = Tracker("namespace", [e1, e2, e3])
 
-        p = Payload({"eid":"event_id"})
-        t.track(p)
+        p = Payload({"eid": "event_id"})
+        tracker = t.track(p)
 
-        e1.input.assert_called_once_with({"eid":"event_id"})
-        e2.input.assert_called_once_with({"eid":"event_id"})
-        e3.input.assert_called_once_with({"eid":"event_id"})
+        e1.input.assert_called_once_with({"eid": "event_id"})
+        e2.input.assert_called_once_with({"eid": "event_id"})
+        e3.input.assert_called_once_with({"eid": "event_id"})
+
+        self.assertEqual(tracker, "event_id")
 
     @freeze_time("2021-04-19 00:00:01")  # unix: 1618790401000
     @mock.patch("snowplow_tracker.Tracker.track")

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -142,7 +142,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]],
         tstamp: Optional[float],
         event_subject: Optional[_subject.Subject],
-    ) -> "Tracker":
+    ) -> str:
         """
         Called by all tracking events to add the standard name-value pairs
         to the Payload object irrespective of the tracked event.
@@ -155,7 +155,7 @@ class Tracker:
         :type   tstamp:          int | float | None
         :param  event_subject:   Optional per event subject
         :type   event_subject:   subject | None
-        :rtype:                  tracker
+        :rtype:                  String
         """
         pb.add("eid", Tracker.get_uuid())
 
@@ -187,7 +187,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  page_url:       URL of the viewed page
         :type   page_url:       non_empty_string
@@ -201,7 +201,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         non_empty_string(page_url)
 
@@ -225,7 +225,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  page_url:       URL of the viewed page
         :type   page_url:       non_empty_string
@@ -247,7 +247,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         non_empty_string(page_url)
 
@@ -273,7 +273,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  target_url:     Target URL of the link
         :type   target_url:     non_empty_string
@@ -291,7 +291,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         non_empty_string(target_url)
 
@@ -325,7 +325,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  sku:            Item SKU or ID
         :type   sku:            non_empty_string
@@ -345,7 +345,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         warn(
             "track_add_to_cart will be deprecated in future versions.",
@@ -385,7 +385,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  sku:            Item SKU or ID
         :type   sku:            non_empty_string
@@ -405,7 +405,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         warn(
             "track_remove_from_cart will be deprecated in future versions.",
@@ -445,7 +445,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  form_id:        ID attribute of the HTML form
         :type   form_id:        non_empty_string
@@ -465,7 +465,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         non_empty_string(form_id)
         one_of(node_name, FORM_NODE_NAMES)
@@ -498,7 +498,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  form_id:        ID attribute of the HTML form
         :type   form_id:        non_empty_string
@@ -512,7 +512,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         non_empty_string(form_id)
         for element in elements or []:
@@ -542,7 +542,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  terms:          Search terms
         :type   terms:          seq[>=1](str)
@@ -558,7 +558,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         non_empty(terms)
 
@@ -591,7 +591,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         This is an internal method called by track_ecommerce_transaction.
         It is not for public use.
@@ -616,7 +616,7 @@ class Tracker:
         :type   tstamp:      int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:              tracker
+        :rtype:              str
         """
         warn(
             "track_ecommerce_transaction_item will be deprecated in future versions.",
@@ -653,7 +653,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  order_id:       ID of the eCommerce transaction
         :type   order_id:       non_empty_string
@@ -681,7 +681,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         warn(
             "track_ecommerce_transaction will be deprecated in future versions.",
@@ -724,7 +724,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  name:           The name of the screen view event
         :type   name:           string_or_none
@@ -736,7 +736,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         warn(
             "track_screen_view will be deprecated in future versions. Please use track_mobile_screen_view.",
@@ -770,7 +770,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  id_:            Screen view ID. This must be of type UUID.
         :type   id_:            string | None
@@ -792,7 +792,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         screen_view_properties = {}
 
@@ -832,7 +832,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  category:       Category of the event
         :type   category:       non_empty_string
@@ -852,7 +852,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 tracker
+        :rtype:                 str
         """
         non_empty_string(category)
         non_empty_string(action)
@@ -873,7 +873,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  event_json:      The properties of the event. Has two field:
                                  A "data" field containing the event properties and
@@ -885,7 +885,7 @@ class Tracker:
         :type   tstamp:          int | float | None
         :param  event_subject:   Optional per event subject
         :type   event_subject:   subject | None
-        :rtype:                  tracker
+        :rtype:                  str
         """
 
         envelope = SelfDescribingJson(
@@ -906,7 +906,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> "Tracker":
+    ) -> str:
         """
         :param  event_json:      The properties of the event. Has two field:
                                  A "data" field containing the event properties and
@@ -918,7 +918,7 @@ class Tracker:
         :type   tstamp:          int | float | None
         :param  event_subject:   Optional per event subject
         :type   event_subject:   subject | None
-        :rtype:                  tracker
+        :rtype:                  str
         """
         warn(
             "track_unstruct_event will be deprecated in future versions. Please use track_self_describing_event.",

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -122,7 +122,7 @@ class Tracker:
     Tracking methods
     """
 
-    def track(self, pb: payload.Payload) -> str:
+    def track(self, pb: payload.Payload) -> Optional[str]:
         """
         Send the payload to a emitter
 

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -122,17 +122,19 @@ class Tracker:
     Tracking methods
     """
 
-    def track(self, pb: payload.Payload) -> "Tracker":
+    def track(self, pb: payload.Payload) -> str:
         """
         Send the payload to a emitter
 
         :param  pb:              Payload builder
         :type   pb:              payload
-        :rtype:                  tracker
+        :rtype:                  String
         """
         for emitter in self.emitters:
             emitter.input(pb.nv_pairs)
-        return self
+
+        if "eid" in pb.nv_pairs.keys():
+            return pb.nv_pairs["eid"]
 
     def complete_payload(
         self,

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -187,7 +187,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  page_url:       URL of the viewed page
         :type   page_url:       non_empty_string
@@ -201,7 +201,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         non_empty_string(page_url)
 
@@ -211,7 +211,8 @@ class Tracker:
         pb.add("page", page_title)
         pb.add("refr", referrer)
 
-        return self.complete_payload(pb, context, tstamp, event_subject)
+        self.complete_payload(pb, context, tstamp, event_subject)
+        return self
 
     def track_page_ping(
         self,
@@ -225,7 +226,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  page_url:       URL of the viewed page
         :type   page_url:       non_empty_string
@@ -247,7 +248,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         non_empty_string(page_url)
 
@@ -261,7 +262,8 @@ class Tracker:
         pb.add("pp_miy", min_y)
         pb.add("pp_may", max_y)
 
-        return self.complete_payload(pb, context, tstamp, event_subject)
+        self.complete_payload(pb, context, tstamp, event_subject)
+        return self
 
     def track_link_click(
         self,
@@ -273,7 +275,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  target_url:     Target URL of the link
         :type   target_url:     non_empty_string
@@ -291,7 +293,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         non_empty_string(target_url)
 
@@ -310,9 +312,8 @@ class Tracker:
             "%s/link_click/%s/1-0-1" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def track_add_to_cart(
         self,
@@ -325,7 +326,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  sku:            Item SKU or ID
         :type   sku:            non_empty_string
@@ -345,7 +346,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         warn(
             "track_add_to_cart will be deprecated in future versions.",
@@ -370,9 +371,8 @@ class Tracker:
             "%s/add_to_cart/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def track_remove_from_cart(
         self,
@@ -385,7 +385,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  sku:            Item SKU or ID
         :type   sku:            non_empty_string
@@ -405,7 +405,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         warn(
             "track_remove_from_cart will be deprecated in future versions.",
@@ -430,9 +430,8 @@ class Tracker:
             "%s/remove_from_cart/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def track_form_change(
         self,
@@ -445,7 +444,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  form_id:        ID attribute of the HTML form
         :type   form_id:        non_empty_string
@@ -465,7 +464,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         non_empty_string(form_id)
         one_of(node_name, FORM_NODE_NAMES)
@@ -486,9 +485,8 @@ class Tracker:
             "%s/change_form/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def track_form_submit(
         self,
@@ -498,7 +496,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  form_id:        ID attribute of the HTML form
         :type   form_id:        non_empty_string
@@ -512,7 +510,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         non_empty_string(form_id)
         for element in elements or []:
@@ -529,9 +527,8 @@ class Tracker:
             "%s/submit_form/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def track_site_search(
         self,
@@ -542,7 +539,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  terms:          Search terms
         :type   terms:          seq[>=1](str)
@@ -558,7 +555,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         non_empty(terms)
 
@@ -575,9 +572,8 @@ class Tracker:
             "%s/site_search/%s/1-0-0" % (BASE_SCHEMA_PATH, SCHEMA_TAG), properties
         )
 
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def track_ecommerce_transaction_item(
         self,
@@ -591,7 +587,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         This is an internal method called by track_ecommerce_transaction.
         It is not for public use.
@@ -616,7 +612,7 @@ class Tracker:
         :type   tstamp:      int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:              str
+        :rtype:              Tracker
         """
         warn(
             "track_ecommerce_transaction_item will be deprecated in future versions.",
@@ -636,7 +632,8 @@ class Tracker:
         pb.add("ti_qu", quantity)
         pb.add("ti_cu", currency)
 
-        return self.complete_payload(pb, context, tstamp, event_subject)
+        self.complete_payload(pb, context, tstamp, event_subject)
+        return self
 
     def track_ecommerce_transaction(
         self,
@@ -653,7 +650,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  order_id:       ID of the eCommerce transaction
         :type   order_id:       non_empty_string
@@ -681,7 +678,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         warn(
             "track_ecommerce_transaction will be deprecated in future versions.",
@@ -724,7 +721,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  name:           The name of the screen view event
         :type   name:           string_or_none
@@ -736,7 +733,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         warn(
             "track_screen_view will be deprecated in future versions. Please use track_mobile_screen_view.",
@@ -754,9 +751,8 @@ class Tracker:
             screen_view_properties,
         )
 
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def track_mobile_screen_view(
         self,
@@ -770,7 +766,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  id_:            Screen view ID. This must be of type UUID.
         :type   id_:            string | None
@@ -792,7 +788,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         screen_view_properties = {}
 
@@ -818,9 +814,8 @@ class Tracker:
             "%s/screen_view/%s/1-0-0" % (MOBILE_SCHEMA_PATH, SCHEMA_TAG),
             screen_view_properties,
         )
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def track_struct_event(
         self,
@@ -832,7 +827,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  category:       Category of the event
         :type   category:       non_empty_string
@@ -852,7 +847,7 @@ class Tracker:
         :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:                 str
+        :rtype:                 Tracker
         """
         non_empty_string(category)
         non_empty_string(action)
@@ -865,7 +860,8 @@ class Tracker:
         pb.add("se_pr", property_)
         pb.add("se_va", value)
 
-        return self.complete_payload(pb, context, tstamp, event_subject)
+        self.complete_payload(pb, context, tstamp, event_subject)
+        return self
 
     def track_self_describing_event(
         self,
@@ -873,7 +869,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  event_json:      The properties of the event. Has two field:
                                  A "data" field containing the event properties and
@@ -885,7 +881,7 @@ class Tracker:
         :type   tstamp:          int | float | None
         :param  event_subject:   Optional per event subject
         :type   event_subject:   subject | None
-        :rtype:                  str
+        :rtype:                  Tracker
         """
 
         envelope = SelfDescribingJson(
@@ -897,7 +893,8 @@ class Tracker:
         pb.add("e", "ue")
         pb.add_json(envelope, self.encode_base64, "ue_px", "ue_pr", self.json_encoder)
 
-        return self.complete_payload(pb, context, tstamp, event_subject)
+        self.complete_payload(pb, context, tstamp, event_subject)
+        return self
 
     # Alias
     def track_unstruct_event(
@@ -906,7 +903,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
         event_subject: Optional[_subject.Subject] = None,
-    ) -> str:
+    ) -> "Tracker":
         """
         :param  event_json:      The properties of the event. Has two field:
                                  A "data" field containing the event properties and
@@ -918,16 +915,15 @@ class Tracker:
         :type   tstamp:          int | float | None
         :param  event_subject:   Optional per event subject
         :type   event_subject:   subject | None
-        :rtype:                  str
+        :rtype:                  Tracker
         """
         warn(
             "track_unstruct_event will be deprecated in future versions. Please use track_self_describing_event.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.track_self_describing_event(
-            event_json, context, tstamp, event_subject
-        )
+        self.track_self_describing_event(event_json, context, tstamp, event_subject)
+        return self
 
     def flush(self, is_async: bool = False) -> "Tracker":
         """

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -124,7 +124,7 @@ class Tracker:
 
     def track(self, pb: payload.Payload) -> Optional[str]:
         """
-        Send the payload to a emitter
+        Send the payload to a emitter. Returns the tracked event ID.
 
         :param  pb:              Payload builder
         :type   pb:              payload
@@ -142,7 +142,7 @@ class Tracker:
         context: Optional[List[SelfDescribingJson]],
         tstamp: Optional[float],
         event_subject: Optional[_subject.Subject],
-    ) -> str:
+    ) -> Optional[str]:
         """
         Called by all tracking events to add the standard name-value pairs
         to the Payload object irrespective of the tracked event.


### PR DESCRIPTION
This PR updates the track function to return the event id instead of the tracker itself.