### PR TITLE
Fix namespace assignment in Snowplow API (close #341)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
         cd tracker_api_example
         python app.py "localhost:9090"
 
+    - name: Demo
+      run: |
+        cd examples
+        cd snowplow_api_example
+        python snowplow_app.py "localhost:9090"
+
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         cd tracker_api_example
         python app.py "localhost:9090"
 
-    - name: Demo
+    - name: Snowplow Demo
       run: |
         cd examples
         cd snowplow_api_example

--- a/snowplow_tracker/snowplow.py
+++ b/snowplow_tracker/snowplow.py
@@ -72,7 +72,7 @@ class Snowplow:
             raise TypeError("Emitter or Collector URL must be provided")
 
         emitter = Emitter(
-            endpoint,
+            endpoint=endpoint,
             method=method,
             batch_size=emitter_config.batch_size,
             on_success=emitter_config.on_success,

--- a/snowplow_tracker/snowplow.py
+++ b/snowplow_tracker/snowplow.py
@@ -85,8 +85,8 @@ class Snowplow:
         )
 
         tracker = Tracker(
-            emitter,
             namespace=namespace,
+            emitters=emitter,
             app_id=app_id,
             subject=subject,
             encode_base64=tracker_config.encode_base64,


### PR DESCRIPTION
This PR fixes a bug in the Snowplow API where the emitter was being assigned as a namespace