### PR TITLE
Refactor track_xxx() methods (close #343)

### DIFF
--- a/examples/redis_example/redis_app.py
+++ b/examples/redis_example/redis_app.py
@@ -1,4 +1,12 @@
-from snowplow_tracker import Tracker
+from snowplow_tracker import (
+    Tracker,
+    ScreenView,
+    PagePing,
+    PageView,
+    SelfDescribing,
+    StructEvent,
+    SelfDescribingJson,
+)
 from snowplow_tracker.typing import PayloadDict
 import json
 import redis
@@ -51,9 +59,27 @@ def main():
 
     t = Tracker(namespace="snowplow_tracker", emitters=emitter)
 
-    t.track_page_view("https://www.snowplow.io", "Homepage")
-    t.track_page_ping("https://www.snowplow.io", "Homepage")
-    t.track_link_click("https://www.snowplow.io")
+    page_view = PageView(page_url="https://www.snowplow.io", page_title="Homepage")
+    t.track(page_view)
+
+    page_ping = PagePing(page_url="https://www.snowplow.io", page_title="Homepage")
+    t.track(page_ping)
+
+    link_click = SelfDescribing(
+        SelfDescribingJson(
+            "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
+            {"targetUrl": "https://www.snowplow.io"},
+        )
+    )
+    t.track(link_click)
+
+    screen_view = ScreenView(id_="id", name="name")
+    t.track(screen_view)
+
+    struct_event = StructEvent(
+        category="shop", action="add-to-basket", property_="pcs", value=2
+    )
+    t.track(struct_event)
 
 
 if __name__ == "__main__":

--- a/examples/redis_example/redis_app.py
+++ b/examples/redis_example/redis_app.py
@@ -4,7 +4,7 @@ from snowplow_tracker import (
     PagePing,
     PageView,
     SelfDescribing,
-    StructEvent,
+    StructuredEvent,
     SelfDescribingJson,
 )
 from snowplow_tracker.typing import PayloadDict
@@ -76,7 +76,7 @@ def main():
     screen_view = ScreenView(id_="id", name="name")
     t.track(screen_view)
 
-    struct_event = StructEvent(
+    struct_event = StructuredEvent(
         category="shop", action="add-to-basket", property_="pcs", value=2
     )
     t.track(struct_event)

--- a/examples/redis_example/redis_app.py
+++ b/examples/redis_example/redis_app.py
@@ -73,7 +73,8 @@ def main():
     )
     t.track(link_click)
 
-    screen_view = ScreenView(id_="id", name="name")
+    id = t.get_uuid()
+    screen_view = ScreenView(id_=id, name="name")
     t.track(screen_view)
 
     struct_event = StructuredEvent(

--- a/examples/snowplow_api_example/snowplow_app.py
+++ b/examples/snowplow_api_example/snowplow_app.py
@@ -5,6 +5,11 @@ from snowplow_tracker import (
     Subject,
     TrackerConfiguration,
     SelfDescribingJson,
+    PagePing,
+    PageView,
+    ScreenView,
+    SelfDescribing,
+    StructEvent,
 )
 
 
@@ -15,11 +20,12 @@ def get_url_from_args():
 
 
 def main():
-
     collector_url = get_url_from_args()
     # Configure Emitter
     custom_retry_codes = {500: False, 401: True}
-    emitter_config = EmitterConfiguration(batch_size=5, custom_retry_codes=custom_retry_codes)
+    emitter_config = EmitterConfiguration(
+        batch_size=5, custom_retry_codes=custom_retry_codes
+    )
 
     # Configure Tracker
     tracker_config = TrackerConfiguration(encode_base64=True)
@@ -39,19 +45,27 @@ def main():
 
     tracker = Snowplow.get_tracker("ns")
 
-    tracker.track_page_view("https://www.snowplow.io", "Homepage")
-    tracker.track_page_ping("https://www.snowplow.io", "Homepage")
-    tracker.track_link_click("https://www.snowplow.io/about")
-    tracker.track_page_view("https://www.snowplow.io/about", "About")
+    page_view = PageView(page_url="https://www.snowplow.io", page_title="Homepage")
+    tracker.track(page_view)
 
-    tracker.track_self_describing_event(
+    page_ping = PagePing(page_url="https://www.snowplow.io", page_title="Homepage")
+    tracker.track(page_ping)
+
+    link_click = SelfDescribing(
         SelfDescribingJson(
             "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
-            {"targetUrl": "example.com"},
+            {"targetUrl": "https://www.snowplow.io"},
         )
     )
-    tracker.track_struct_event("shop", "add-to-basket", None, "pcs", 2)
+    tracker.track(link_click)
 
+    screen_view = ScreenView(id_="id", name="name")
+    tracker.track(screen_view)
+
+    struct_event = StructEvent(
+        category="shop", action="add-to-basket", property_="pcs", value=2
+    )
+    tracker.track(struct_event)
     tracker.flush()
 
 

--- a/examples/snowplow_api_example/snowplow_app.py
+++ b/examples/snowplow_api_example/snowplow_app.py
@@ -59,7 +59,8 @@ def main():
     )
     tracker.track(link_click)
 
-    screen_view = ScreenView(id_="id", name="name")
+    id = tracker.get_uuid()
+    screen_view = ScreenView(id_=id, name="name")
     tracker.track(screen_view)
 
     struct_event = StructuredEvent(

--- a/examples/snowplow_api_example/snowplow_app.py
+++ b/examples/snowplow_api_example/snowplow_app.py
@@ -9,7 +9,7 @@ from snowplow_tracker import (
     PageView,
     ScreenView,
     SelfDescribing,
-    StructEvent,
+    StructuredEvent,
 )
 
 
@@ -62,7 +62,7 @@ def main():
     screen_view = ScreenView(id_="id", name="name")
     tracker.track(screen_view)
 
-    struct_event = StructEvent(
+    struct_event = StructuredEvent(
         category="shop", action="add-to-basket", property_="pcs", value=2
     )
     tracker.track(struct_event)

--- a/examples/tracker_api_example/app.py
+++ b/examples/tracker_api_example/app.py
@@ -8,7 +8,7 @@ from snowplow_tracker import (
     PagePing,
     SelfDescribing,
     ScreenView,
-    StructEvent,
+    StructuredEvent,
 )
 import sys
 
@@ -57,7 +57,7 @@ def main():
     screen_view = ScreenView(id_="id", name="name", event_subject=t.subject)
     t.track(screen_view)
 
-    struct_event = StructEvent(
+    struct_event = StructuredEvent(
         category="shop",
         action="add-to-basket",
         property_="pcs",

--- a/examples/tracker_api_example/app.py
+++ b/examples/tracker_api_example/app.py
@@ -31,25 +31,38 @@ def main():
 
     print("Sending events to " + e.endpoint)
 
-    page_view = PageView(page_url="https://www.snowplow.io", page_title="Homepage")
+    page_view = PageView(
+        page_url="https://www.snowplow.io",
+        page_title="Homepage",
+        event_subject=t.subject,
+    )
     t.track(page_view)
 
-    page_ping = PagePing(page_url="https://www.snowplow.io", page_title="Homepage")
+    page_ping = PagePing(
+        page_url="https://www.snowplow.io",
+        page_title="Homepage",
+        event_subject=t.subject,
+    )
     t.track(page_ping)
 
     link_click = SelfDescribing(
         SelfDescribingJson(
             "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
             {"targetUrl": "https://www.snowplow.io"},
-        )
+        ),
+        event_subject=t.subject,
     )
     t.track(link_click)
 
-    screen_view = ScreenView(id_="id", name="name")
+    screen_view = ScreenView(id_="id", name="name", event_subject=t.subject)
     t.track(screen_view)
 
     struct_event = StructEvent(
-        category="shop", action="add-to-basket", property_="pcs", value=2
+        category="shop",
+        action="add-to-basket",
+        property_="pcs",
+        value=2,
+        event_subject=t.subject,
     )
     t.track(struct_event)
     t.flush()

--- a/examples/tracker_api_example/app.py
+++ b/examples/tracker_api_example/app.py
@@ -54,7 +54,8 @@ def main():
     )
     t.track(link_click)
 
-    screen_view = ScreenView(id_="id", name="name", event_subject=t.subject)
+    id = t.get_uuid()
+    screen_view = ScreenView(id_=id, name="name", event_subject=t.subject)
     t.track(screen_view)
 
     struct_event = StructuredEvent(

--- a/examples/tracker_api_example/app.py
+++ b/examples/tracker_api_example/app.py
@@ -4,6 +4,11 @@ from snowplow_tracker import (
     Emitter,
     Subject,
     SelfDescribingJson,
+    PageView,
+    PagePing,
+    SelfDescribing,
+    ScreenView,
+    StructEvent,
 )
 import sys
 
@@ -26,17 +31,27 @@ def main():
 
     print("Sending events to " + e.endpoint)
 
-    t.track_page_view("https://www.snowplow.io", "Homepage")
-    t.track_page_ping("https://www.snowplow.io", "Homepage")
-    t.track_link_click("https://www.snowplow.io")
+    page_view = PageView(page_url="https://www.snowplow.io", page_title="Homepage")
+    t.track(page_view)
 
-    t.track_self_describing_event(
+    page_ping = PagePing(page_url="https://www.snowplow.io", page_title="Homepage")
+    t.track(page_ping)
+
+    link_click = SelfDescribing(
         SelfDescribingJson(
             "iglu:com.snowplowanalytics.snowplow/link_click/jsonschema/1-0-1",
-            {"targetUrl": "example.com"},
+            {"targetUrl": "https://www.snowplow.io"},
         )
     )
-    t.track_struct_event("shop", "add-to-basket", None, "pcs", 2)
+    t.track(link_click)
+
+    screen_view = ScreenView(id_="id", name="name")
+    t.track(screen_view)
+
+    struct_event = StructEvent(
+        category="shop", action="add-to-basket", property_="pcs", value=2
+    )
+    t.track(struct_event)
     t.flush()
 
 

--- a/snowplow_tracker/__init__.py
+++ b/snowplow_tracker/__init__.py
@@ -10,7 +10,7 @@ from snowplow_tracker.contracts import disable_contracts, enable_contracts
 from snowplow_tracker.event_store import EventStore
 from snowplow_tracker.events import (
     Event,
-    Pageview,
+    PageView,
     PagePing,
     SelfDescribing,
     StructEvent,

--- a/snowplow_tracker/__init__.py
+++ b/snowplow_tracker/__init__.py
@@ -14,4 +14,5 @@ from snowplow_tracker.events import (
     PagePing,
     SelfDescribing,
     StructEvent,
+    ScreenView,
 )

--- a/snowplow_tracker/__init__.py
+++ b/snowplow_tracker/__init__.py
@@ -13,6 +13,6 @@ from snowplow_tracker.events import (
     PageView,
     PagePing,
     SelfDescribing,
-    StructEvent,
+    StructuredEvent,
     ScreenView,
 )

--- a/snowplow_tracker/constants.py
+++ b/snowplow_tracker/constants.py
@@ -1,4 +1,19 @@
-# constants.py
+# """
+#     constants.py
+
+#     Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
+
+#     This program is licensed to you under the Apache License Version 2.0,
+#     and you may not use this file except in compliance with the Apache License
+#     Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+#     http://www.apache.org/licenses/LICENSE-2.0.
+
+#     Unless required by applicable law or agreed to in writing,
+#     software distributed under the Apache License Version 2.0 is distributed on
+#     an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#     express or implied. See the Apache License Version 2.0 for the specific
+#     language governing permissions and limitations there under.
+# """
 from typing import List
 from snowplow_tracker import _version, SelfDescribingJson
 

--- a/snowplow_tracker/events/__init__.py
+++ b/snowplow_tracker/events/__init__.py
@@ -18,5 +18,5 @@ from snowplow_tracker.events.event import Event
 from snowplow_tracker.events.page_ping import PagePing
 from snowplow_tracker.events.page_view import PageView
 from snowplow_tracker.events.self_describing import SelfDescribing
-from snowplow_tracker.events.struct_event import StructEvent
+from snowplow_tracker.events.structured_event import StructuredEvent
 from snowplow_tracker.events.screen_view import ScreenView

--- a/snowplow_tracker/events/__init__.py
+++ b/snowplow_tracker/events/__init__.py
@@ -1,3 +1,19 @@
+# """
+#     __init__.py
+
+#     Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
+
+#     This program is licensed to you under the Apache License Version 2.0,
+#     and you may not use this file except in compliance with the Apache License
+#     Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+#     http://www.apache.org/licenses/LICENSE-2.0.
+
+#     Unless required by applicable law or agreed to in writing,
+#     software distributed under the Apache License Version 2.0 is distributed on
+#     an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#     express or implied. See the Apache License Version 2.0 for the specific
+#     language governing permissions and limitations there under.
+# """
 from snowplow_tracker.events.event import Event
 from snowplow_tracker.events.page_ping import PagePing
 from snowplow_tracker.events.page_view import PageView

--- a/snowplow_tracker/events/__init__.py
+++ b/snowplow_tracker/events/__init__.py
@@ -1,5 +1,5 @@
 from snowplow_tracker.events.event import Event
 from snowplow_tracker.events.page_ping import PagePing
-from snowplow_tracker.events.pageview import Pageview
+from snowplow_tracker.events.page_view import PageView
 from snowplow_tracker.events.self_describing import SelfDescribing
 from snowplow_tracker.events.struct_event import StructEvent

--- a/snowplow_tracker/events/__init__.py
+++ b/snowplow_tracker/events/__init__.py
@@ -19,3 +19,4 @@ from snowplow_tracker.events.page_ping import PagePing
 from snowplow_tracker.events.page_view import PageView
 from snowplow_tracker.events.self_describing import SelfDescribing
 from snowplow_tracker.events.struct_event import StructEvent
+from snowplow_tracker.events.screen_view import ScreenView

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -26,6 +26,17 @@ from snowplow_tracker.typing import JsonEncoderFunction, PayloadDict
 
 
 class Event(object):
+    """
+    Event class which contains
+    elements that can be set in all events. These are context, trueTimestamp, and Subject.
+
+    Context is a list of custom SelfDescribingJson entities.
+    TrueTimestamp is a user-defined timestamp.
+    Subject is an event-specific Subject. Its fields will override those of the
+    Tracker-associated Subject, if present.
+
+    """
+
     def __init__(self, dict_: Optional[PayloadDict] = None) -> None:
         """
         Constructor

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -42,7 +42,7 @@ class Event(object):
         dict_: Optional[PayloadDict] = None,
         event_subject: Optional[_subject.Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
-        tstamp: Optional[float] = None,
+        true_timestamp: Optional[float] = None,
     ) -> None:
         """
         Constructor
@@ -52,14 +52,14 @@ class Event(object):
         :type   event_subject:   subject | None
         :param  context:         Custom context for the event
         :type   context:         context_array | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
+        :param  true_timestamp:          Optional event timestamp in milliseconds
+        :type   true_timestamp:          int | float | None
 
         """
         self.payload = payload.Payload(dict_=dict_)
         self.event_subject = event_subject
         self.context = context
-        self.tstamp = tstamp
+        self.true_timestamp = true_timestamp
 
     def build_payload(
         self,
@@ -89,7 +89,7 @@ class Event(object):
             )
 
         if isinstance(
-            self.tstamp,
+            self.true_timestamp,
             (
                 int,
                 float,
@@ -124,12 +124,12 @@ class Event(object):
         self._context = value
 
     @property
-    def tstamp(self) -> Optional[str]:
+    def true_timestamp(self) -> Optional[str]:
         """
         Optional event timestamp in milliseconds
         """
-        return self._tstamp
+        return self._true_timestamp
 
-    @tstamp.setter
-    def tstamp(self, value: Optional[_subject.Subject]):
-        self._tstamp = value
+    @true_timestamp.setter
+    def true_timestamp(self, value: Optional[_subject.Subject]):
+        self._true_timestamp = value

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -58,7 +58,7 @@ class Event(object):
         """
         self.payload = payload.Payload(dict_=dict_)
         self.event_subject = event_subject
-        self.context = context
+        self.context = context or []
         self.true_timestamp = true_timestamp
 
     def build_payload(
@@ -76,7 +76,7 @@ class Event(object):
         :type   subject:         subject | None
         :rtype:                  payload.Payload
         """
-        if self.context is not None:
+        if len(self.context) > 0:
             context_jsons = list(map(lambda c: c.to_json(), self.context))
             context_envelope = SelfDescribingJson(
                 CONTEXT_SCHEMA, context_jsons
@@ -112,14 +112,14 @@ class Event(object):
         self._event_subject = value
 
     @property
-    def context(self) -> Optional[List[SelfDescribingJson]]:
+    def context(self) -> List[SelfDescribingJson]:
         """
         Custom context for the event
         """
         return self._context
 
     @context.setter
-    def context(self, value: Optional[List[SelfDescribingJson]]):
+    def context(self, value: List[SelfDescribingJson]):
         self._context = value
 
     @property

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -46,6 +46,15 @@ class Event(object):
     ) -> None:
         """
         Constructor
+        :param  dict_:           Optional Dictionary to be added to the Events Payload
+        :type   dict_:           dict(string:\\*) | None
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :param  tstamp:          Optional event timestamp in milliseconds
+        :type   tstamp:          int | float | None
+
         """
         self.payload = payload.Payload(dict_=dict_)
         self.event_subject = event_subject

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -91,3 +91,36 @@ class Event(object):
         if self.event_subject is not None:
             self.payload.add_dict(self.event_subject.standard_nv_pairs)
         return self.payload
+
+    @property
+    def event_subject(self) -> Optional[_subject.Subject]:
+        """
+        Optional per event subject
+        """
+        return self._event_subject
+
+    @event_subject.setter
+    def event_subject(self, value: Optional[_subject.Subject]):
+        self._event_subject = value
+
+    @property
+    def context(self) -> Optional[List[SelfDescribingJson]]:
+        """
+        Custom context for the event
+        """
+        return self._context
+
+    @context.setter
+    def context(self, value: Optional[List[SelfDescribingJson]]):
+        self._context = value
+
+    @property
+    def tstamp(self) -> Optional[str]:
+        """
+        Optional event timestamp in milliseconds
+        """
+        return self._tstamp
+
+    @tstamp.setter
+    def tstamp(self, value: Optional[_subject.Subject]):
+        self._tstamp = value

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -37,19 +37,25 @@ class Event(object):
 
     """
 
-    def __init__(self, dict_: Optional[PayloadDict] = None) -> None:
+    def __init__(
+        self,
+        dict_: Optional[PayloadDict] = None,
+        event_subject: Optional[_subject.Subject] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
+        tstamp: Optional[float] = None,
+    ) -> None:
         """
         Constructor
         """
         self.payload = payload.Payload(dict_=dict_)
+        self.event_subject = event_subject
+        self.context = context
+        self.tstamp = tstamp
 
     def build_payload(
         self,
-        event_subject: Optional[_subject.Subject],
         encode_base64: bool,
         json_encoder: Optional[JsonEncoderFunction],
-        tstamp: Optional[float],
-        context: Optional[List[SelfDescribingJson]],
     ) -> "payload.Payload":
         """
         :param  event_subject:   Optional per event subject
@@ -64,8 +70,8 @@ class Event(object):
         :type   context:         context_array | None
         :rtype:                  payload.Payload
         """
-        if context is not None:
-            context_jsons = list(map(lambda c: c.to_json(), context))
+        if self.context is not None:
+            context_jsons = list(map(lambda c: c.to_json(), self.context))
             context_envelope = SelfDescribingJson(
                 CONTEXT_SCHEMA, context_jsons
             ).to_json()
@@ -74,13 +80,14 @@ class Event(object):
             )
 
         if isinstance(
-            tstamp,
+            self.tstamp,
             (
                 int,
                 float,
             ),
         ):
-            self.payload.add("ttm", int(tstamp))
+            self.payload.add("ttm", int(self.tstamp))
 
-        self.payload.add_dict(event_subject.standard_nv_pairs)
+        if self.event_subject is not None:
+            self.payload.add_dict(self.event_subject.standard_nv_pairs)
         return self.payload

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -17,7 +17,7 @@
 
 from typing import Optional, List
 from snowplow_tracker import payload
-from snowplow_tracker import subject as _subject
+from snowplow_tracker.subject import Subject
 
 from snowplow_tracker.self_describing_json import SelfDescribingJson
 
@@ -40,7 +40,7 @@ class Event(object):
     def __init__(
         self,
         dict_: Optional[PayloadDict] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
     ) -> None:
@@ -65,7 +65,7 @@ class Event(object):
         self,
         encode_base64: bool,
         json_encoder: Optional[JsonEncoderFunction],
-        subject: Optional[_subject.Subject] = None,
+        subject: Optional[Subject] = None,
     ) -> "payload.Payload":
         """
         :param encode_base64:    Whether JSONs in the payload should be base-64 encoded
@@ -101,14 +101,14 @@ class Event(object):
         return self.payload
 
     @property
-    def event_subject(self) -> Optional[_subject.Subject]:
+    def event_subject(self) -> Optional[Subject]:
         """
         Optional per event subject
         """
         return self._event_subject
 
     @event_subject.setter
-    def event_subject(self, value: Optional[_subject.Subject]):
+    def event_subject(self, value: Optional[Subject]):
         self._event_subject = value
 
     @property

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -65,18 +65,15 @@ class Event(object):
         self,
         encode_base64: bool,
         json_encoder: Optional[JsonEncoderFunction],
+        subject: Optional[_subject.Subject] = None,
     ) -> "payload.Payload":
         """
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
         :param encode_base64:    Whether JSONs in the payload should be base-64 encoded
         :type  encode_base64:    bool
         :param json_encoder:     Custom JSON serializer that gets called on non-serializable object
         :type  json_encoder:     function | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
+        :param  subject:         Optional per event subject
+        :type   subject:         subject | None
         :rtype:                  payload.Payload
         """
         if self.context is not None:
@@ -95,10 +92,12 @@ class Event(object):
                 float,
             ),
         ):
-            self.payload.add("ttm", int(self.tstamp))
+            self.payload.add("ttm", int(self.true_timestamp))
 
-        if self.event_subject is not None:
-            self.payload.add_dict(self.event_subject.standard_nv_pairs)
+        fin_subject = self.event_subject if self.event_subject is not None else subject
+
+        if fin_subject is not None:
+            self.payload.add_dict(fin_subject.standard_nv_pairs)
         return self.payload
 
     @property

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -46,14 +46,14 @@ class Event(object):
     ) -> None:
         """
         Constructor
-        :param  dict_:           Optional Dictionary to be added to the Events Payload
-        :type   dict_:           dict(string:\\*) | None
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
-        :param  true_timestamp:          Optional event timestamp in milliseconds
-        :type   true_timestamp:          int | float | None
+        :param  dict_:              Optional Dictionary to be added to the Events Payload
+        :type   dict_:              dict(string:\\*) | None
+        :param  event_subject:      Optional per event subject
+        :type   event_subject:      subject | None
+        :param  context:            Custom context for the event
+        :type   context:            context_array | None
+        :param  true_timestamp:     Optional event timestamp in milliseconds
+        :type   true_timestamp:     int | float | None
 
         """
         self.payload = payload.Payload(dict_=dict_)

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -30,7 +30,7 @@ class Event(object):
         """
         Constructor
         """
-        self.pb = payload.Payload(dict_=dict_)
+        self.payload = payload.Payload(dict_=dict_)
 
     def build_payload(
         self,
@@ -58,7 +58,9 @@ class Event(object):
             context_envelope = SelfDescribingJson(
                 CONTEXT_SCHEMA, context_jsons
             ).to_json()
-            self.pb.add_json(context_envelope, encode_base64, "cx", "co", json_encoder)
+            self.payload.add_json(
+                context_envelope, encode_base64, "cx", "co", json_encoder
+            )
 
         if isinstance(
             tstamp,
@@ -67,7 +69,7 @@ class Event(object):
                 float,
             ),
         ):
-            self.pb.add("ttm", int(tstamp))
+            self.payload.add("ttm", int(tstamp))
 
-        self.pb.add_dict(event_subject.standard_nv_pairs)
-        return self.pb
+        self.payload.add_dict(event_subject.standard_nv_pairs)
+        return self.payload

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -123,12 +123,12 @@ class Event(object):
         self._context = value
 
     @property
-    def true_timestamp(self) -> Optional[str]:
+    def true_timestamp(self) -> Optional[float]:
         """
         Optional event timestamp in milliseconds
         """
         return self._true_timestamp
 
     @true_timestamp.setter
-    def true_timestamp(self, value: Optional[_subject.Subject]):
+    def true_timestamp(self, value: Optional[float]):
         self._true_timestamp = value

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -80,81 +80,74 @@ class PagePing(Event):
         """
         URL of the viewed page
         """
-        return self._page_url
+        return self.payload.get("url")
 
     @page_url.setter
     def page_url(self, value: Optional[str]):
-        self._page_url = value
-        self.payload.add("url", self._page_url)
+        self.payload.add("url", value)
 
     @property
     def page_title(self) -> Optional[str]:
         """
         URL of the viewed page
         """
-        return self._page_title
+        return self.payload.get("page")
 
     @page_title.setter
     def page_title(self, value: Optional[str]):
-        self._page_title = value
-        self.payload.add("page", self._page_title)
+        self.payload.add("page", value)
 
     @property
     def referrer(self) -> Optional[str]:
         """
         The referrer of the page
         """
-        return self._referrer
+        return self.payload.get("refr")
 
     @referrer.setter
     def referrer(self, value: Optional[str]):
-        self._referrer = value
-        self.payload.add("refr", self._referrer)
+        self.payload.add("refr", value)
 
     @property
     def min_x(self) -> Optional[int]:
         """
         Minimum page x offset seen in the last ping period
         """
-        return self._min_x
+        return self.payload.get("pp_mix")
 
     @min_x.setter
     def min_x(self, value: Optional[int]):
-        self._min_x = value
-        self.payload.add("pp_mix", self._min_x)
+        self.payload.add("pp_mix", value)
 
     @property
     def max_x(self) -> Optional[int]:
         """
         Maximum page x offset seen in the last ping period
         """
-        return self._max_x
+        return self.payload.get("pp_max")
 
     @min_x.setter
     def max_x(self, value: Optional[int]):
-        self._max_x = value
-        self.payload.add("pp_max", self._max_x)
+        self.payload.add("pp_max", value)
 
     @property
     def min_y(self) -> Optional[int]:
         """
         Minimum page y offset seen in the last ping period
         """
-        return self._min_y
+        return self.payload.get("pp_miy")
 
     @min_y.setter
     def min_y(self, value: Optional[int]):
-        self._min_y = value
-        self.payload.add("pp_miy", self._min_y)
+        self.payload.add("pp_miy", value)
 
     @property
     def max_y(self) -> Optional[int]:
         """
         Maximum page y offset seen in the last ping period
         """
-        return self._max_y
+        return self.payload.get("pp_may")
 
     @min_y.setter
     def max_y(self, value: Optional[int]):
-        self._max_y = value
-        self.payload.add("pp_may", self._max_y)
+        self.payload.add("pp_may", value)

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -19,6 +19,13 @@ from typing import Optional
 
 
 class PagePing(Event):
+    """
+    Constructs a PagePing event object.
+
+    When tracked, generates a "pp" or "page_ping" event.
+
+    """
+
     def __init__(
         self,
         page_url: Optional[str] = None,

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -40,6 +40,7 @@ class PagePing(Event):
         max_x: Optional[int] = None,
         min_y: Optional[int] = None,
         max_y: Optional[int] = None,
+        true_timestamp: Optional[float] = None,
     ) -> None:
         """
         :param  event_subject:   Optional per event subject
@@ -62,9 +63,11 @@ class PagePing(Event):
         :type   min_y:          int | None
         :param  max_y:          Maximum page y offset seen in the last ping period
         :type   max_y:          int | None
+        :param  true_timestamp:          Optional event timestamp in milliseconds
+        :type   true_timestamp:          int | float | None
         """
         super(PagePing, self).__init__(
-            event_subject=event_subject, context=context, tstamp=tstamp
+            event_subject=event_subject, context=context, true_timestamp=true_timestamp
         )
         self.payload.add("e", "pp")
         self.page_url = page_url

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -15,7 +15,9 @@
 #     language governing permissions and limitations there under.
 # """
 from snowplow_tracker.events.event import Event
-from typing import Optional
+from typing import Optional, List
+from snowplow_tracker.self_describing_json import SelfDescribingJson
+from snowplow_tracker import subject as _subject
 
 
 class PagePing(Event):
@@ -28,6 +30,9 @@ class PagePing(Event):
 
     def __init__(
         self,
+        event_subject: Optional[_subject.Subject] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
+        tstamp: Optional[float] = None,
         page_url: Optional[str] = None,
         page_title: Optional[str] = None,
         referrer: Optional[str] = None,
@@ -52,7 +57,9 @@ class PagePing(Event):
         :param  max_y:          Maximum page y offset seen in the last ping period
         :type   max_y:          int | None
         """
-        super(PagePing, self).__init__()
+        super(PagePing, self).__init__(
+            event_subject=event_subject, context=context, tstamp=tstamp
+        )
         self.payload.add("e", "pp")
         self.page_url = page_url
         self.page_title = page_title

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -17,7 +17,7 @@
 from snowplow_tracker.events.event import Event
 from typing import Optional, List
 from snowplow_tracker.self_describing_json import SelfDescribingJson
-from snowplow_tracker import subject as _subject
+from snowplow_tracker.subject import Subject
 
 
 class PagePing(Event):
@@ -37,7 +37,7 @@ class PagePing(Event):
         max_x: Optional[int] = None,
         min_y: Optional[int] = None,
         max_y: Optional[int] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
     ) -> None:

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -18,6 +18,7 @@ from snowplow_tracker.events.event import Event
 from typing import Optional, List
 from snowplow_tracker.self_describing_json import SelfDescribingJson
 from snowplow_tracker.subject import Subject
+from snowplow_tracker.contracts import non_empty_string
 
 
 class PagePing(Event):
@@ -76,14 +77,15 @@ class PagePing(Event):
         self.max_y = max_y
 
     @property
-    def page_url(self) -> Optional[str]:
+    def page_url(self) -> str:
         """
         URL of the viewed page
         """
         return self.payload.get("url")
 
     @page_url.setter
-    def page_url(self, value: Optional[str]):
+    def page_url(self, value: str):
+        non_empty_string(value)
         self.payload.add("url", value)
 
     @property
@@ -126,7 +128,7 @@ class PagePing(Event):
         """
         return self.payload.get("pp_max")
 
-    @min_x.setter
+    @max_x.setter
     def max_x(self, value: Optional[int]):
         self.payload.add("pp_max", value)
 
@@ -148,6 +150,6 @@ class PagePing(Event):
         """
         return self.payload.get("pp_may")
 
-    @min_y.setter
+    @max_y.setter
     def max_y(self, value: Optional[int]):
         self.payload.add("pp_may", value)

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -46,7 +46,7 @@ class PagePing(Event):
         :type   max_y:          int | None
         """
         super(PagePing, self).__init__()
-        self.pb.add("e", "pp")
+        self.payload.add("e", "pp")
         self.page_url = page_url
         self.page_title = page_title
         self.referrer = referrer
@@ -65,7 +65,7 @@ class PagePing(Event):
     @page_url.setter
     def page_url(self, value: Optional[str]):
         self._page_url = value
-        self.pb.add("url", self._page_url)
+        self.payload.add("url", self._page_url)
 
     @property
     def page_title(self) -> Optional[str]:
@@ -77,7 +77,7 @@ class PagePing(Event):
     @page_title.setter
     def page_title(self, value: Optional[str]):
         self._page_title = value
-        self.pb.add("page", self._page_title)
+        self.payload.add("page", self._page_title)
 
     @property
     def referrer(self) -> Optional[str]:
@@ -89,7 +89,7 @@ class PagePing(Event):
     @referrer.setter
     def referrer(self, value: Optional[str]):
         self._referrer = value
-        self.pb.add("refr", self._referrer)
+        self.payload.add("refr", self._referrer)
 
     @property
     def min_x(self) -> Optional[int]:
@@ -101,7 +101,7 @@ class PagePing(Event):
     @min_x.setter
     def min_x(self, value: Optional[int]):
         self._min_x = value
-        self.pb.add("pp_mix", self._min_x)
+        self.payload.add("pp_mix", self._min_x)
 
     @property
     def max_x(self) -> Optional[int]:
@@ -113,7 +113,7 @@ class PagePing(Event):
     @min_x.setter
     def max_x(self, value: Optional[int]):
         self._max_x = value
-        self.pb.add("pp_max", self._max_x)
+        self.payload.add("pp_max", self._max_x)
 
     @property
     def min_y(self) -> Optional[int]:
@@ -125,7 +125,7 @@ class PagePing(Event):
     @min_y.setter
     def min_y(self, value: Optional[int]):
         self._min_y = value
-        self.pb.add("pp_miy", self._min_y)
+        self.payload.add("pp_miy", self._min_y)
 
     @property
     def max_y(self) -> Optional[int]:
@@ -137,4 +137,4 @@ class PagePing(Event):
     @min_y.setter
     def max_y(self, value: Optional[int]):
         self._max_y = value
-        self.pb.add("pp_may", self._max_y)
+        self.payload.add("pp_may", self._max_y)

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -30,25 +30,18 @@ class PagePing(Event):
 
     def __init__(
         self,
-        event_subject: Optional[_subject.Subject] = None,
-        context: Optional[List[SelfDescribingJson]] = None,
-        tstamp: Optional[float] = None,
-        page_url: Optional[str] = None,
+        page_url: str,
         page_title: Optional[str] = None,
         referrer: Optional[str] = None,
         min_x: Optional[int] = None,
         max_x: Optional[int] = None,
         min_y: Optional[int] = None,
         max_y: Optional[int] = None,
+        event_subject: Optional[_subject.Subject] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
     ) -> None:
         """
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
         :param  page_url:       URL of the viewed page
         :type   page_url:       non_empty_string
         :param  page_title:     Title of the viewed page
@@ -63,6 +56,10 @@ class PagePing(Event):
         :type   min_y:          int | None
         :param  max_y:          Maximum page y offset seen in the last ping period
         :type   max_y:          int | None
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
         :param  true_timestamp:          Optional event timestamp in milliseconds
         :type   true_timestamp:          int | float | None
         """

--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -42,6 +42,12 @@ class PagePing(Event):
         max_y: Optional[int] = None,
     ) -> None:
         """
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :param  tstamp:          Optional event timestamp in milliseconds
+        :type   tstamp:          int | float | None
         :param  page_url:       URL of the viewed page
         :type   page_url:       non_empty_string
         :param  page_title:     Title of the viewed page

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -64,7 +64,7 @@ class PageView(Event):
         """
         URL of the viewed page
         """
-        return self._page_url
+        return self.payload.get("url")
 
     @page_url.setter
     def page_url(self, value: Optional[str]):
@@ -76,7 +76,7 @@ class PageView(Event):
         """
         Title of the viewed page
         """
-        return self._page_title
+        return self.payload.get("page")
 
     @page_title.setter
     def page_title(self, value: Optional[str]):
@@ -88,7 +88,7 @@ class PageView(Event):
         """
         The referrer of the page
         """
-        return self._referrer
+        return self.payload.get("refr")
 
     @referrer.setter
     def referrer(self, value: Optional[str]):

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -38,6 +38,12 @@ class PageView(Event):
         referrer: Optional[str] = None,
     ) -> None:
         """
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :param  tstamp:          Optional event timestamp in milliseconds
+        :type   tstamp:          int | float | None
         :param  page_url:       URL of the viewed page
         :type   page_url:       non_empty_string
         :param  page_title:     Title of the viewed page

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -18,6 +18,7 @@ from snowplow_tracker.events.event import Event
 from typing import Optional, List
 from snowplow_tracker.subject import Subject
 from snowplow_tracker.self_describing_json import SelfDescribingJson
+from snowplow_tracker.contracts import non_empty_string
 
 
 class PageView(Event):
@@ -68,6 +69,7 @@ class PageView(Event):
 
     @page_url.setter
     def page_url(self, value: str):
+        non_empty_string(value)
         self.payload.add("url", value)
 
     @property

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -34,7 +34,7 @@ class PageView(Event):
         :type   referrer:       string_or_none
         """
         super(PageView, self).__init__()
-        self.pb.add("e", "pv")
+        self.payload.add("e", "pv")
         self.page_url = page_url
         self.page_title = page_title
         self.referrer = referrer
@@ -49,7 +49,7 @@ class PageView(Event):
     @page_url.setter
     def page_url(self, value: Optional[str]):
         self._page_url = value
-        self.pb.add("url", self._page_url)
+        self.payload.add("url", self._page_url)
 
     @property
     def page_title(self) -> Optional[str]:
@@ -61,7 +61,7 @@ class PageView(Event):
     @page_title.setter
     def page_title(self, value: Optional[str]):
         self._page_title = value
-        self.pb.add("page", self._page_title)
+        self.payload.add("page", self._page_title)
 
     @property
     def referrer(self) -> Optional[str]:
@@ -73,4 +73,4 @@ class PageView(Event):
     @referrer.setter
     def referrer(self, value: Optional[str]):
         self._referrer = value
-        self.pb.add("refr", self._referrer)
+        self.payload.add("refr", self._referrer)

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -1,5 +1,5 @@
 # """
-#     pageview.py
+#     page_view.py
 
 #     Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
 
@@ -18,7 +18,7 @@ from snowplow_tracker.events.event import Event
 from typing import Optional
 
 
-class Pageview(Event):
+class PageView(Event):
     def __init__(
         self,
         page_url: Optional[str] = None,
@@ -33,7 +33,7 @@ class Pageview(Event):
         :param  referrer:       Referrer of the page
         :type   referrer:       string_or_none
         """
-        super(Pageview, self).__init__()
+        super(PageView, self).__init__()
         self.pb.add("e", "pv")
         self.page_url = page_url
         self.page_title = page_title

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -16,7 +16,7 @@
 # """
 from snowplow_tracker.events.event import Event
 from typing import Optional, List
-from snowplow_tracker import subject as _subject
+from snowplow_tracker.subject import Subject
 from snowplow_tracker.self_describing_json import SelfDescribingJson
 
 
@@ -33,7 +33,7 @@ class PageView(Event):
         page_url: str,
         page_title: Optional[str] = None,
         referrer: Optional[str] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
     ) -> None:

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -60,14 +60,14 @@ class PageView(Event):
         self.referrer = referrer
 
     @property
-    def page_url(self) -> Optional[str]:
+    def page_url(self) -> str:
         """
         URL of the viewed page
         """
         return self.payload.get("url")
 
     @page_url.setter
-    def page_url(self, value: Optional[str]):
+    def page_url(self, value: str):
         self.payload.add("url", value)
 
     @property

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -30,6 +30,9 @@ class PageView(Event):
 
     def __init__(
         self,
+        page_url: str,
+        page_title: Optional[str] = None,
+        referrer: Optional[str] = None,
         event_subject: Optional[_subject.Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
@@ -47,6 +50,10 @@ class PageView(Event):
         :type   page_title:     string_or_none
         :param  referrer:       Referrer of the page
         :type   referrer:       string_or_none
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
         :param  true_timestamp:          Optional event timestamp in milliseconds
         :type   true_timestamp:          int | float | None
         """

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -38,12 +38,6 @@ class PageView(Event):
         true_timestamp: Optional[float] = None,
     ) -> None:
         """
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
         :param  page_url:       URL of the viewed page
         :type   page_url:       non_empty_string
         :param  page_title:     Title of the viewed page
@@ -74,8 +68,7 @@ class PageView(Event):
 
     @page_url.setter
     def page_url(self, value: Optional[str]):
-        self._page_url = value
-        self.payload.add("url", self._page_url)
+        self.payload.add("url", value)
 
     @property
     def page_title(self) -> Optional[str]:
@@ -86,8 +79,7 @@ class PageView(Event):
 
     @page_title.setter
     def page_title(self, value: Optional[str]):
-        self._page_title = value
-        self.payload.add("page", self._page_title)
+        self.payload.add("page", value)
 
     @property
     def referrer(self) -> Optional[str]:
@@ -98,5 +90,4 @@ class PageView(Event):
 
     @referrer.setter
     def referrer(self, value: Optional[str]):
-        self._referrer = value
-        self.payload.add("refr", self._referrer)
+        self.payload.add("refr", value)

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -15,7 +15,9 @@
 #     language governing permissions and limitations there under.
 # """
 from snowplow_tracker.events.event import Event
-from typing import Optional
+from typing import Optional, List
+from snowplow_tracker import subject as _subject
+from snowplow_tracker.self_describing_json import SelfDescribingJson
 
 
 class PageView(Event):
@@ -28,6 +30,9 @@ class PageView(Event):
 
     def __init__(
         self,
+        event_subject: Optional[_subject.Subject] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
+        tstamp: Optional[float] = None,
         page_url: Optional[str] = None,
         page_title: Optional[str] = None,
         referrer: Optional[str] = None,
@@ -40,7 +45,9 @@ class PageView(Event):
         :param  referrer:       Referrer of the page
         :type   referrer:       string_or_none
         """
-        super(PageView, self).__init__()
+        super(PageView, self).__init__(
+            event_subject=event_subject, context=context, tstamp=tstamp
+        )
         self.payload.add("e", "pv")
         self.page_url = page_url
         self.page_title = page_title

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -19,6 +19,13 @@ from typing import Optional
 
 
 class PageView(Event):
+    """
+    Constructs a PageView event object.
+
+    When tracked, generates a "pv" or "page_view" event.
+
+    """
+
     def __init__(
         self,
         page_url: Optional[str] = None,

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -32,10 +32,7 @@ class PageView(Event):
         self,
         event_subject: Optional[_subject.Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
-        tstamp: Optional[float] = None,
-        page_url: Optional[str] = None,
-        page_title: Optional[str] = None,
-        referrer: Optional[str] = None,
+        true_timestamp: Optional[float] = None,
     ) -> None:
         """
         :param  event_subject:   Optional per event subject
@@ -50,9 +47,11 @@ class PageView(Event):
         :type   page_title:     string_or_none
         :param  referrer:       Referrer of the page
         :type   referrer:       string_or_none
+        :param  true_timestamp:          Optional event timestamp in milliseconds
+        :type   true_timestamp:          int | float | None
         """
         super(PageView, self).__init__(
-            event_subject=event_subject, context=context, tstamp=tstamp
+            event_subject=event_subject, context=context, true_timestamp=true_timestamp
         )
         self.payload.add("e", "pv")
         self.page_url = page_url

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -76,7 +76,6 @@ class ScreenView(Event):
         super(ScreenView, self).__init__(
             event_subject=event_subject, context=context, true_timestamp=true_timestamp
         )
-        self.payload.add("e", "ue")
         self.screen_view_properties = {}
         self.id_ = id_
         self.name = name

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -48,6 +48,7 @@ class ScreenView(Event):
         previous_id: Optional[str] = None,
         previous_type: Optional[str] = None,
         transition_type: Optional[str] = None,
+        true_timestamp: Optional[float] = None,
     ) -> None:
         """
         :param  event_subject:   Optional per event subject
@@ -70,9 +71,11 @@ class ScreenView(Event):
         :type   previous_type   string | None
         :param  transition_type The type of transition that led to the screen being viewed.
         :type   transition_type string | None
+        :param  true_timestamp:  Optional event timestamp in milliseconds
+        :type   true_timestamp:  int | float | None
         """
         super(ScreenView, self).__init__(
-            event_subject=event_subject, context=context, tstamp=tstamp
+            event_subject=event_subject, context=context, true_timestamp=true_timestamp
         )
         self.payload.add("e", "ue")
         self.screen_view_properties = {}

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -50,12 +50,26 @@ class ScreenView(Event):
         transition_type: Optional[str] = None,
     ) -> None:
         """
-        :param  page_url:       URL of the viewed page
-        :type   page_url:       non_empty_string
-        :param  page_title:     Title of the viewed page
-        :type   page_title:     string_or_none
-        :param  referrer:       Referrer of the page
-        :type   referrer:       string_or_none
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :param  tstamp:          Optional event timestamp in milliseconds
+        :type   tstamp:          int | float | None
+        :param  id_:            Screen view ID. This must be of type UUID.
+        :type   id_:            string | None
+        :param  name:           The name of the screen view event
+        :type   name:           string_or_none
+        :param  type:           The type of screen that was viewed e.g feed / carousel.
+        :type   type:           string | None
+        :param  previous_name:  The name of the previous screen.
+        :type   previous_name:  string | None
+        :param  previous_id:    The screenview ID of the previous screenview.
+        :type   previous_id:    string | None
+        :param  previous_type   The screen type of the previous screenview
+        :type   previous_type   string | None
+        :param  transition_type The type of transition that led to the screen being viewed.
+        :type   transition_type string | None
         """
         super(ScreenView, self).__init__(
             event_subject=event_subject, context=context, tstamp=tstamp
@@ -73,7 +87,7 @@ class ScreenView(Event):
     @property
     def id_(self) -> Optional[str]:
         """
-        URL of the viewed page
+        Screen view ID. This must be of type UUID.
         """
         return self._id_
 
@@ -86,7 +100,7 @@ class ScreenView(Event):
     @property
     def name(self) -> Optional[str]:
         """
-        URL of the viewed page
+        The name of the screen view event
         """
         return self._name
 
@@ -99,7 +113,7 @@ class ScreenView(Event):
     @property
     def type(self) -> Optional[str]:
         """
-        URL of the viewed page
+        The type of screen that was viewed e.g feed / carousel
         """
         return self._type
 
@@ -112,7 +126,7 @@ class ScreenView(Event):
     @property
     def previous_name(self) -> Optional[str]:
         """
-        URL of the viewed page
+        The name of the previous screen.
         """
         return self._previous_name
 
@@ -125,7 +139,7 @@ class ScreenView(Event):
     @property
     def previous_id(self) -> Optional[str]:
         """
-        URL of the viewed page
+        The screenview ID of the previous screenview.
         """
         return self._previous_id
 
@@ -138,7 +152,7 @@ class ScreenView(Event):
     @property
     def previous_type(self) -> Optional[str]:
         """
-        URL of the viewed page
+        The screen type of the previous screenview
         """
         return self._previous_type
 
@@ -151,7 +165,7 @@ class ScreenView(Event):
     @property
     def transition_type(self) -> Optional[str]:
         """
-        URL of the viewed page
+        The type of transition that led to the screen being viewed
         """
         return self._transition_type
 

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -38,6 +38,9 @@ class ScreenView(Event):
 
     def __init__(
         self,
+        event_subject: Optional[_subject.Subject] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
+        tstamp: Optional[float] = None,
         id_: Optional[str] = None,
         name: Optional[str] = None,
         type: Optional[str] = None,
@@ -54,7 +57,9 @@ class ScreenView(Event):
         :param  referrer:       Referrer of the page
         :type   referrer:       string_or_none
         """
-        super(ScreenView, self).__init__()
+        super(ScreenView, self).__init__(
+            event_subject=event_subject, context=context, tstamp=tstamp
+        )
         self.payload.add("e", "ue")
         self.screen_view_properties = {}
         self.id_ = id_
@@ -158,11 +163,8 @@ class ScreenView(Event):
 
     def build_payload(
         self,
-        event_subject: Optional[_subject.Subject],
         encode_base64: bool,
         json_encoder: Optional[JsonEncoderFunction],
-        tstamp: Optional[float],
-        context: Optional[List[SelfDescribingJson]],
     ) -> "payload.Payload":
         """
         :param  event_subject:   Optional per event subject
@@ -177,8 +179,8 @@ class ScreenView(Event):
         :type   context:         context_array | None
         :rtype:                  payload.Payload
         """
-        if context is not None:
-            context_jsons = list(map(lambda c: c.to_json(), context))
+        if self.context is not None:
+            context_jsons = list(map(lambda c: c.to_json(), self.context))
             context_envelope = SelfDescribingJson(
                 CONTEXT_SCHEMA, context_jsons
             ).to_json()
@@ -187,15 +189,16 @@ class ScreenView(Event):
             )
 
         if isinstance(
-            tstamp,
+            self.tstamp,
             (
                 int,
                 float,
             ),
         ):
-            self.payload.add("ttm", int(tstamp))
+            self.payload.add("ttm", int(self.tstamp))
 
-        self.payload.add_dict(event_subject.standard_nv_pairs)
+        if self.event_subject is not None:
+            self.payload.add_dict(self.event_subject.standard_nv_pairs)
 
         event_json = SelfDescribingJson(
             "%s/screen_view/%s/1-0-0" % (MOBILE_SCHEMA_PATH, SCHEMA_TAG),

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -48,19 +48,15 @@ class ScreenView(Event):
         previous_id: Optional[str] = None,
         previous_type: Optional[str] = None,
         transition_type: Optional[str] = None,
+        event_subject: Optional[_subject.Subject] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
     ) -> None:
         """
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
         :param  id_:            Screen view ID. This must be of type UUID.
-        :type   id_:            string | None
+        :type   id_:            string
         :param  name:           The name of the screen view event
-        :type   name:           string_or_none
+        :type   name:           string
         :param  type:           The type of screen that was viewed e.g feed / carousel.
         :type   type:           string | None
         :param  previous_name:  The name of the previous screen.
@@ -71,6 +67,10 @@ class ScreenView(Event):
         :type   previous_type   string | None
         :param  transition_type The type of transition that led to the screen being viewed.
         :type   transition_type string | None
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
         :param  true_timestamp:  Optional event timestamp in milliseconds
         :type   true_timestamp:  int | float | None
         """

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -27,7 +27,7 @@ from snowplow_tracker.constants import (
     SCHEMA_TAG,
 )
 from snowplow_tracker import payload
-from snowplow_tracker import subject as _subject
+from snowplow_tracker.subject import Subject
 
 
 class ScreenView(Event):
@@ -48,7 +48,7 @@ class ScreenView(Event):
         previous_id: Optional[str] = None,
         previous_type: Optional[str] = None,
         transition_type: Optional[str] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
     ) -> None:
@@ -173,7 +173,7 @@ class ScreenView(Event):
         self,
         encode_base64: bool,
         json_encoder: Optional[JsonEncoderFunction],
-        subject: Optional[_subject.Subject] = None,
+        subject: Optional[Subject] = None,
     ) -> "payload.Payload":
         """
         :param encode_base64:    Whether JSONs in the payload should be base-64 encoded

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -21,13 +21,12 @@ from snowplow_tracker.events.event import Event
 from snowplow_tracker.events.self_describing import SelfDescribing
 from snowplow_tracker import SelfDescribingJson
 from snowplow_tracker.constants import (
-    UNSTRUCT_EVENT_SCHEMA,
-    CONTEXT_SCHEMA,
     MOBILE_SCHEMA_PATH,
     SCHEMA_TAG,
 )
 from snowplow_tracker import payload
 from snowplow_tracker.subject import Subject
+from snowplow_tracker.contracts import non_empty_string
 
 
 class ScreenView(Event):
@@ -96,6 +95,7 @@ class ScreenView(Event):
 
     @id_.setter
     def id_(self, value: str):
+        non_empty_string(value)
         self.screen_view_properties["id"] = value
 
     @property
@@ -107,6 +107,7 @@ class ScreenView(Event):
 
     @name.setter
     def name(self, value: str):
+        non_empty_string(value)
         self.screen_view_properties["name"] = value
 
     @property
@@ -197,5 +198,3 @@ class ScreenView(Event):
         return self_describing.build_payload(
             encode_base64, json_encoder, subject=subject
         )
-
-        return self.payload

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -106,7 +106,7 @@ class ScreenView(Event):
         return self.screen_view_properties["name"]
 
     @name.setter
-    def name(self, value: Optional[str]):
+    def name(self, value: str):
         self.screen_view_properties["name"] = value
 
     @property

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -35,6 +35,8 @@ class ScreenView(Event):
     Constructs a ScreenView event object.
 
     When tracked, generates a SelfDescribing event (event type "ue").
+
+    Schema: `iglu:com.snowplowanalytics.mobile/screen_view/jsonschema/1-0-0`
     """
 
     def __init__(

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -30,6 +30,12 @@ from snowplow_tracker import subject as _subject
 
 
 class ScreenView(Event):
+    """
+    Constructs a ScreenView event object.
+
+    When tracked, generates a SelfDescribing event (event type "ue").
+    """
+
     def __init__(
         self,
         id_: Optional[str] = None,

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -182,18 +182,15 @@ class ScreenView(Event):
         self,
         encode_base64: bool,
         json_encoder: Optional[JsonEncoderFunction],
+        subject: Optional[_subject.Subject] = None,
     ) -> "payload.Payload":
         """
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
         :param encode_base64:    Whether JSONs in the payload should be base-64 encoded
         :type  encode_base64:    bool
         :param json_encoder:     Custom JSON serializer that gets called on non-serializable object
         :type  json_encoder:     function | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
+        :param  subject:         Optional per event subject
+        :type   subject:         subject | None
         :rtype:                  payload.Payload
         """
         if self.context is not None:

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -1,0 +1,204 @@
+# """
+#     screen_view.py
+
+#     Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
+
+#     This program is licensed to you under the Apache License Version 2.0,
+#     and you may not use this file except in compliance with the Apache License
+#     Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+#     http://www.apache.org/licenses/LICENSE-2.0.
+
+#     Unless required by applicable law or agreed to in writing,
+#     software distributed under the Apache License Version 2.0 is distributed on
+#     an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#     express or implied. See the Apache License Version 2.0 for the specific
+#     language governing permissions and limitations there under.
+# """
+
+from typing import Optional, List
+from snowplow_tracker.typing import JsonEncoderFunction
+from snowplow_tracker.events.event import Event
+from snowplow_tracker import SelfDescribingJson
+from snowplow_tracker.constants import (
+    UNSTRUCT_EVENT_SCHEMA,
+    CONTEXT_SCHEMA,
+    MOBILE_SCHEMA_PATH,
+    SCHEMA_TAG,
+)
+from snowplow_tracker import payload
+from snowplow_tracker import subject as _subject
+
+
+class ScreenView(Event):
+    def __init__(
+        self,
+        id_: Optional[str] = None,
+        name: Optional[str] = None,
+        type: Optional[str] = None,
+        previous_name: Optional[str] = None,
+        previous_id: Optional[str] = None,
+        previous_type: Optional[str] = None,
+        transition_type: Optional[str] = None,
+    ) -> None:
+        """
+        :param  page_url:       URL of the viewed page
+        :type   page_url:       non_empty_string
+        :param  page_title:     Title of the viewed page
+        :type   page_title:     string_or_none
+        :param  referrer:       Referrer of the page
+        :type   referrer:       string_or_none
+        """
+        super(ScreenView, self).__init__()
+        self.payload.add("e", "ue")
+        self.screen_view_properties = {}
+        self.id_ = id_
+        self.name = name
+        self.type = type
+        self.previous_name = previous_name
+        self.previous_id = previous_id
+        self.previous_type = previous_type
+        self.transition_type = transition_type
+
+    @property
+    def id_(self) -> Optional[str]:
+        """
+        URL of the viewed page
+        """
+        return self._id_
+
+    @id_.setter
+    def id_(self, value: Optional[str]):
+        self._id_ = value
+        if self._id_ is not None:
+            self.screen_view_properties["id"] = self._id_
+
+    @property
+    def name(self) -> Optional[str]:
+        """
+        URL of the viewed page
+        """
+        return self._name
+
+    @name.setter
+    def name(self, value: Optional[str]):
+        self._name = value
+        if self._name is not None:
+            self.screen_view_properties["name"] = self._name
+
+    @property
+    def type(self) -> Optional[str]:
+        """
+        URL of the viewed page
+        """
+        return self._type
+
+    @type.setter
+    def type(self, value: Optional[str]):
+        self._type = value
+        if self._type is not None:
+            self.screen_view_properties["type"] = self._type
+
+    @property
+    def previous_name(self) -> Optional[str]:
+        """
+        URL of the viewed page
+        """
+        return self._previous_name
+
+    @previous_name.setter
+    def previous_name(self, value: Optional[str]):
+        self._previous_name = value
+        if self._previous_name is not None:
+            self.screen_view_properties["previousName"] = self._previous_name
+
+    @property
+    def previous_id(self) -> Optional[str]:
+        """
+        URL of the viewed page
+        """
+        return self._previous_id
+
+    @previous_id.setter
+    def previous_id(self, value: Optional[str]):
+        self._previous_id = value
+        if self._previous_id is not None:
+            self.screen_view_properties["previousId"] = self._previous_id
+
+    @property
+    def previous_type(self) -> Optional[str]:
+        """
+        URL of the viewed page
+        """
+        return self._previous_type
+
+    @previous_type.setter
+    def previous_type(self, value: Optional[str]):
+        self._previous_type = value
+        if self._previous_type is not None:
+            self.screen_view_properties["previousType"] = self._previous_type
+
+    @property
+    def transition_type(self) -> Optional[str]:
+        """
+        URL of the viewed page
+        """
+        return self._transition_type
+
+    @transition_type.setter
+    def transition_type(self, value: Optional[str]):
+        self._transition_type = value
+        if self._transition_type is not None:
+            self.screen_view_properties["transitionType"] = self._transition_type
+
+    def build_payload(
+        self,
+        event_subject: Optional[_subject.Subject],
+        encode_base64: bool,
+        json_encoder: Optional[JsonEncoderFunction],
+        tstamp: Optional[float],
+        context: Optional[List[SelfDescribingJson]],
+    ) -> "payload.Payload":
+        """
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param encode_base64:    Whether JSONs in the payload should be base-64 encoded
+        :type  encode_base64:    bool
+        :param json_encoder:     Custom JSON serializer that gets called on non-serializable object
+        :type  json_encoder:     function | None
+        :param  tstamp:          Optional event timestamp in milliseconds
+        :type   tstamp:          int | float | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :rtype:                  payload.Payload
+        """
+        if context is not None:
+            context_jsons = list(map(lambda c: c.to_json(), context))
+            context_envelope = SelfDescribingJson(
+                CONTEXT_SCHEMA, context_jsons
+            ).to_json()
+            self.payload.add_json(
+                context_envelope, encode_base64, "cx", "co", json_encoder
+            )
+
+        if isinstance(
+            tstamp,
+            (
+                int,
+                float,
+            ),
+        ):
+            self.payload.add("ttm", int(tstamp))
+
+        self.payload.add_dict(event_subject.standard_nv_pairs)
+
+        event_json = SelfDescribingJson(
+            "%s/screen_view/%s/1-0-0" % (MOBILE_SCHEMA_PATH, SCHEMA_TAG),
+            self.screen_view_properties,
+        )
+
+        envelope = SelfDescribingJson(
+            UNSTRUCT_EVENT_SCHEMA, event_json.to_json()
+        ).to_json()
+        self.payload.add_json(envelope, encode_base64, "ue_px", "ue_pr", json_encoder)
+
+        return self.payload

--- a/snowplow_tracker/events/screen_view.py
+++ b/snowplow_tracker/events/screen_view.py
@@ -38,11 +38,8 @@ class ScreenView(Event):
 
     def __init__(
         self,
-        event_subject: Optional[_subject.Subject] = None,
-        context: Optional[List[SelfDescribingJson]] = None,
-        tstamp: Optional[float] = None,
-        id_: Optional[str] = None,
-        name: Optional[str] = None,
+        id_: str,
+        name: str,
         type: Optional[str] = None,
         previous_name: Optional[str] = None,
         previous_id: Optional[str] = None,
@@ -88,95 +85,86 @@ class ScreenView(Event):
         self.transition_type = transition_type
 
     @property
-    def id_(self) -> Optional[str]:
+    def id_(self) -> str:
         """
         Screen view ID. This must be of type UUID.
         """
-        return self._id_
+        return self.screen_view_properties["id"]
 
     @id_.setter
-    def id_(self, value: Optional[str]):
-        self._id_ = value
-        if self._id_ is not None:
-            self.screen_view_properties["id"] = self._id_
+    def id_(self, value: str):
+        self.screen_view_properties["id"] = value
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str:
         """
         The name of the screen view event
         """
-        return self._name
+        return self.screen_view_properties["name"]
 
     @name.setter
     def name(self, value: Optional[str]):
-        self._name = value
-        if self._name is not None:
-            self.screen_view_properties["name"] = self._name
+        self.screen_view_properties["name"] = value
 
     @property
     def type(self) -> Optional[str]:
         """
         The type of screen that was viewed e.g feed / carousel
         """
-        return self._type
+        return self.screen_view_properties["type"]
 
     @type.setter
     def type(self, value: Optional[str]):
-        self._type = value
-        if self._type is not None:
-            self.screen_view_properties["type"] = self._type
+        if value is not None:
+            self.screen_view_properties["type"] = value
 
     @property
     def previous_name(self) -> Optional[str]:
         """
         The name of the previous screen.
         """
-        return self._previous_name
+        return self.screen_view_properties["previousName"]
 
     @previous_name.setter
     def previous_name(self, value: Optional[str]):
-        self._previous_name = value
-        if self._previous_name is not None:
-            self.screen_view_properties["previousName"] = self._previous_name
+        if value is not None:
+            self.screen_view_properties["previousName"] = value
 
     @property
     def previous_id(self) -> Optional[str]:
         """
         The screenview ID of the previous screenview.
         """
-        return self._previous_id
+        return self.screen_view_properties["previousId"]
 
     @previous_id.setter
     def previous_id(self, value: Optional[str]):
-        self._previous_id = value
-        if self._previous_id is not None:
-            self.screen_view_properties["previousId"] = self._previous_id
+        if value is not None:
+            self.screen_view_properties["previousId"] = value
 
     @property
     def previous_type(self) -> Optional[str]:
         """
         The screen type of the previous screenview
         """
-        return self._previous_type
+        return self.screen_view_properties["previousType"]
 
     @previous_type.setter
     def previous_type(self, value: Optional[str]):
-        self._previous_type = value
-        if self._previous_type is not None:
-            self.screen_view_properties["previousType"] = self._previous_type
+        if value is not None:
+            self.screen_view_properties["previousType"] = value
 
     @property
     def transition_type(self) -> Optional[str]:
         """
         The type of transition that led to the screen being viewed
         """
-        return self._transition_type
+        return self.screen_view_properties["transitionType"]
 
     @transition_type.setter
     def transition_type(self, value: Optional[str]):
-        self._transition_type = value
-        if self._transition_type is not None:
-            self.screen_view_properties["transitionType"] = self._transition_type
+        if value is not None:
+            self.screen_view_properties["transitionType"] = value
 
     def build_payload(
         self,

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -21,7 +21,7 @@ from snowplow_tracker import SelfDescribingJson
 from snowplow_tracker.constants import UNSTRUCT_EVENT_SCHEMA
 from snowplow_tracker import payload
 from snowplow_tracker.subject import Subject
-from snowplow_tracker.constants import CONTEXT_SCHEMA
+from snowplow_tracker.contracts import non_empty
 
 
 class SelfDescribing(Event):
@@ -70,6 +70,7 @@ class SelfDescribing(Event):
 
     @event_json.setter
     def event_json(self, value: SelfDescribingJson):
+        non_empty(value)
         self._event_json = value
 
     def build_payload(

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -87,30 +87,12 @@ class SelfDescribing(Event):
         :type   subject:         subject | None
         :rtype:                  payload.Payload
         """
-        if self.context is not None:
-            context_jsons = list(map(lambda c: c.to_json(), self.context))
-            context_envelope = SelfDescribingJson(
-                CONTEXT_SCHEMA, context_jsons
-            ).to_json()
-            self.payload.add_json(
-                context_envelope, encode_base64, "cx", "co", json_encoder
-            )
-
-        if isinstance(
-            self.tstamp,
-            (
-                int,
-                float,
-            ),
-        ):
-            self.payload.add("ttm", int(self.tstamp))
-
-        if self.event_subject is not None:
-            self.payload.add_dict(self.event_subject.standard_nv_pairs)
 
         envelope = SelfDescribingJson(
             UNSTRUCT_EVENT_SCHEMA, self.event_json.to_json()
         ).to_json()
         self.payload.add_json(envelope, encode_base64, "ue_px", "ue_pr", json_encoder)
 
-        return self.payload
+        return super(SelfDescribing, self).build_payload(
+            encode_base64=encode_base64, json_encoder=json_encoder, subject=subject
+        )

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -70,7 +70,6 @@ class SelfDescribing(Event):
 
     @event_json.setter
     def event_json(self, value: SelfDescribingJson):
-        non_empty(value)
         self._event_json = value
 
     def build_payload(

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -25,6 +25,15 @@ from snowplow_tracker.constants import CONTEXT_SCHEMA
 
 
 class SelfDescribing(Event):
+    """
+    Constructs a SelfDescribing event object.
+
+    This is a customisable event type which allows you to track anything describable
+    by a JsonSchema.
+
+    When tracked, generates a self-describing event (event type "ue").
+    """
+
     def __init__(
         self,
         event_json: SelfDescribingJson,

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -41,7 +41,7 @@ class SelfDescribing(Event):
         :type  json_encoder:     function | None
         """
         super(SelfDescribing, self).__init__()
-        self.pb.add("e", "ue")
+        self.payload.add("e", "ue")
         self.encode_base64 = encode_base64
         self.json_encoder = json_encoder
         self.event_json = event_json
@@ -86,6 +86,6 @@ class SelfDescribing(Event):
         envelope = SelfDescribingJson(
             UNSTRUCT_EVENT_SCHEMA, self.event_json.to_json()
         ).to_json()
-        self.pb.add_json(
+        self.payload.add_json(
             envelope, self.encode_base64, "ue_px", "ue_pr", self.json_encoder
         )

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -76,18 +76,15 @@ class SelfDescribing(Event):
         self,
         encode_base64: bool,
         json_encoder: Optional[JsonEncoderFunction],
+        subject: Optional[_subject.Subject] = None,
     ) -> "payload.Payload":
         """
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
         :param encode_base64:    Whether JSONs in the payload should be base-64 encoded
         :type  encode_base64:    bool
         :param json_encoder:     Custom JSON serializer that gets called on non-serializable object
         :type  json_encoder:     function | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
+        :param  subject:         Optional per event subject
+        :type   subject:         subject | None
         :rtype:                  payload.Payload
         """
         if self.context is not None:

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -20,7 +20,7 @@ from snowplow_tracker.events.event import Event
 from snowplow_tracker import SelfDescribingJson
 from snowplow_tracker.constants import UNSTRUCT_EVENT_SCHEMA
 from snowplow_tracker import payload
-from snowplow_tracker import subject as _subject
+from snowplow_tracker.subject import Subject
 from snowplow_tracker.constants import CONTEXT_SCHEMA
 
 
@@ -37,7 +37,7 @@ class SelfDescribing(Event):
     def __init__(
         self,
         event_json: SelfDescribingJson,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
     ) -> None:
@@ -76,7 +76,7 @@ class SelfDescribing(Event):
         self,
         encode_base64: bool,
         json_encoder: Optional[JsonEncoderFunction],
-        subject: Optional[_subject.Subject] = None,
+        subject: Optional[Subject] = None,
     ) -> "payload.Payload":
         """
         :param encode_base64:    Whether JSONs in the payload should be base-64 encoded

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -14,11 +14,14 @@
 #     express or implied. See the Apache License Version 2.0 for the specific
 #     language governing permissions and limitations there under.
 # """
-from typing import Optional
+from typing import Optional, List
 from snowplow_tracker.typing import JsonEncoderFunction
 from snowplow_tracker.events.event import Event
 from snowplow_tracker import SelfDescribingJson
 from snowplow_tracker.constants import UNSTRUCT_EVENT_SCHEMA
+from snowplow_tracker import payload
+from snowplow_tracker import subject as _subject
+from snowplow_tracker.constants import CONTEXT_SCHEMA
 
 
 class SelfDescribing(Event):

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -1,6 +1,3 @@
-from snowplow_tracker.events.event import Event
-from snowplow_tracker import SelfDescribingJson
-
 # """
 #     self_describing.py
 
@@ -19,7 +16,8 @@ from snowplow_tracker import SelfDescribingJson
 # """
 from typing import Optional
 from snowplow_tracker.typing import JsonEncoderFunction
-
+from snowplow_tracker.events.event import Event
+from snowplow_tracker import SelfDescribingJson
 from snowplow_tracker.constants import UNSTRUCT_EVENT_SCHEMA
 
 

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -25,8 +25,6 @@ class SelfDescribing(Event):
     def __init__(
         self,
         event_json: SelfDescribingJson,
-        encode_base64: bool,
-        json_encoder: Optional[JsonEncoderFunction],
     ) -> None:
         """
         :param  event_json:      The properties of the event. Has two field:
@@ -40,8 +38,6 @@ class SelfDescribing(Event):
         """
         super(SelfDescribing, self).__init__()
         self.payload.add("e", "ue")
-        self.encode_base64 = encode_base64
-        self.json_encoder = json_encoder
         self.event_json = event_json
 
     @property
@@ -56,7 +52,6 @@ class SelfDescribing(Event):
     @event_json.setter
     def event_json(self, value: SelfDescribingJson):
         self._event_json = value
-        self.set_payload()
 
     def build_payload(
         self,

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -46,10 +46,12 @@ class SelfDescribing(Event):
                                  A "data" field containing the event properties and
                                  A "schema" field identifying the schema against which the data is validated
         :type   event_json:      self_describing_json
-        :param encode_base64:    Whether JSONs in the payload should be base-64 encoded
-        :type  encode_base64:    bool
-        :param json_encoder:     Custom JSON serializer that gets called on non-serializable object
-        :type  json_encoder:     function | None
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :param  tstamp:          Optional event timestamp in milliseconds
+        :type   tstamp:          int | float | None
         """
         super(SelfDescribing, self).__init__(
             event_subject=event_subject, context=context, tstamp=tstamp

--- a/snowplow_tracker/events/self_describing.py
+++ b/snowplow_tracker/events/self_describing.py
@@ -39,7 +39,7 @@ class SelfDescribing(Event):
         event_json: SelfDescribingJson,
         event_subject: Optional[_subject.Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
-        tstamp: Optional[float] = None,
+        true_timestamp: Optional[float] = None,
     ) -> None:
         """
         :param  event_json:      The properties of the event. Has two field:
@@ -50,11 +50,11 @@ class SelfDescribing(Event):
         :type   event_subject:   subject | None
         :param  context:         Custom context for the event
         :type   context:         context_array | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
+        :param  true_timestamp:          Optional event timestamp in milliseconds
+        :type   true_timestamp:          int | float | None
         """
         super(SelfDescribing, self).__init__(
-            event_subject=event_subject, context=context, tstamp=tstamp
+            event_subject=event_subject, context=context, true_timestamp=true_timestamp
         )
         self.payload.add("e", "ue")
         self.event_json = event_json

--- a/snowplow_tracker/events/struct_event.py
+++ b/snowplow_tracker/events/struct_event.py
@@ -42,7 +42,7 @@ class StructEvent(Event):
         :type   value:          int | float | None
         """
         super(StructEvent, self).__init__()
-        self.pb.add("e", "se")
+        self.payload.add("e", "se")
         self.category = category
         self.action = action
         self.label = label
@@ -59,7 +59,7 @@ class StructEvent(Event):
     @category.setter
     def category(self, value: Optional[str]):
         self._category = value
-        self.pb.add("se_ca", self._category)
+        self.payload.add("se_ca", self._category)
 
     @property
     def action(self) -> Optional[str]:
@@ -71,7 +71,7 @@ class StructEvent(Event):
     @action.setter
     def action(self, value: Optional[str]):
         self._action = value
-        self.pb.add("se_ac", self._action)
+        self.payload.add("se_ac", self._action)
 
     @property
     def label(self) -> Optional[str]:
@@ -83,7 +83,7 @@ class StructEvent(Event):
     @label.setter
     def label(self, value: Optional[str]):
         self._label = value
-        self.pb.add("se_la", self._label)
+        self.payload.add("se_la", self._label)
 
     @property
     def property_(self) -> Optional[str]:
@@ -95,7 +95,7 @@ class StructEvent(Event):
     @property_.setter
     def property_(self, value: Optional[str]):
         self._property_ = value
-        self.pb.add("se_pr", self._property_)
+        self.payload.add("se_pr", self._property_)
 
     @property
     def value(self) -> Optional[int]:
@@ -107,4 +107,4 @@ class StructEvent(Event):
     @value.setter
     def value(self, value: Optional[int]):
         self._value = value
-        self.pb.add("se_va", self._value)
+        self.payload.add("se_va", self._value)

--- a/snowplow_tracker/events/struct_event.py
+++ b/snowplow_tracker/events/struct_event.py
@@ -15,7 +15,9 @@
 #     language governing permissions and limitations there under.
 # """
 from snowplow_tracker.events.event import Event
-from typing import Optional
+from typing import Optional, List
+from snowplow_tracker import subject as _subject
+from snowplow_tracker.self_describing_json import SelfDescribingJson
 
 
 class StructEvent(Event):
@@ -36,6 +38,9 @@ class StructEvent(Event):
         self,
         category: str,
         action: str,
+        event_subject: Optional[_subject.Subject] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
+        tstamp: Optional[float] = None,
         label: Optional[str] = None,
         property_: Optional[str] = None,
         value: Optional[int] = None,
@@ -54,7 +59,9 @@ class StructEvent(Event):
         :param  value:          A value associated with the user action
         :type   value:          int | float | None
         """
-        super(StructEvent, self).__init__()
+        super(StructEvent, self).__init__(
+            event_subject=event_subject, context=context, tstamp=tstamp
+        )
         self.payload.add("e", "se")
         self.category = category
         self.action = action

--- a/snowplow_tracker/events/struct_event.py
+++ b/snowplow_tracker/events/struct_event.py
@@ -50,6 +50,12 @@ class StructEvent(Event):
         :type   category:       non_empty_string
         :param  action:         The event itself
         :type   action:         non_empty_string
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :param  tstamp:          Optional event timestamp in milliseconds
+        :type   tstamp:          int | float | None
         :param  label:          Refer to the object the action is
                                 performed on
         :type   label:          string_or_none

--- a/snowplow_tracker/events/struct_event.py
+++ b/snowplow_tracker/events/struct_event.py
@@ -19,6 +19,19 @@ from typing import Optional
 
 
 class StructEvent(Event):
+    """
+    Constructs a Structured event object.
+
+    This event type is provided to be roughly equivalent to Google Analytics-style events.
+    Note that it is not automatically clear what data should be placed in what field.
+    To aid data quality and modeling, agree on business-wide definitions when designing
+    your tracking strategy.
+
+    We recommend using SelfDescribing - fully custom - events instead.
+
+    When tracked, generates a "struct" or "se" event.
+    """
+
     def __init__(
         self,
         category: str,

--- a/snowplow_tracker/events/structured_event.py
+++ b/snowplow_tracker/events/structured_event.py
@@ -16,7 +16,7 @@
 # """
 from snowplow_tracker.events.event import Event
 from typing import Optional, List
-from snowplow_tracker import subject as _subject
+from snowplow_tracker.subject import Subject
 from snowplow_tracker.self_describing_json import SelfDescribingJson
 
 
@@ -41,7 +41,7 @@ class StructuredEvent(Event):
         label: Optional[str] = None,
         property_: Optional[str] = None,
         value: Optional[int] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         true_timestamp: Optional[float] = None,
     ) -> None:

--- a/snowplow_tracker/events/structured_event.py
+++ b/snowplow_tracker/events/structured_event.py
@@ -20,7 +20,7 @@ from snowplow_tracker import subject as _subject
 from snowplow_tracker.self_describing_json import SelfDescribingJson
 
 
-class StructEvent(Event):
+class StructuredEvent(Event):
     """
     Constructs a Structured event object.
 
@@ -38,24 +38,18 @@ class StructEvent(Event):
         self,
         category: str,
         action: str,
-        event_subject: Optional[_subject.Subject] = None,
-        context: Optional[List[SelfDescribingJson]] = None,
-        tstamp: Optional[float] = None,
         label: Optional[str] = None,
         property_: Optional[str] = None,
         value: Optional[int] = None,
+        event_subject: Optional[_subject.Subject] = None,
+        context: Optional[List[SelfDescribingJson]] = None,
+        true_timestamp: Optional[float] = None,
     ) -> None:
         """
         :param  category:       Category of the event
         :type   category:       non_empty_string
         :param  action:         The event itself
         :type   action:         non_empty_string
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
         :param  label:          Refer to the object the action is
                                 performed on
         :type   label:          string_or_none
@@ -64,9 +58,15 @@ class StructEvent(Event):
         :type   property_:      string_or_none
         :param  value:          A value associated with the user action
         :type   value:          int | float | None
+        :param  event_subject:   Optional per event subject
+        :type   event_subject:   subject | None
+        :param  context:         Custom context for the event
+        :type   context:         context_array | None
+        :param  true_timestamp:          Optional event timestamp in milliseconds
+        :type   true_timestamp:          int | float | None
         """
-        super(StructEvent, self).__init__(
-            event_subject=event_subject, context=context, tstamp=tstamp
+        super(StructuredEvent, self).__init__(
+            event_subject=event_subject, context=context, true_timestamp=true_timestamp
         )
         self.payload.add("e", "se")
         self.category = category
@@ -80,57 +80,52 @@ class StructEvent(Event):
         """
         Category of the event
         """
-        return self._category
+        return self.payload.get("se_ca")
 
     @category.setter
     def category(self, value: Optional[str]):
-        self._category = value
-        self.payload.add("se_ca", self._category)
+        self.payload.add("se_ca", value)
 
     @property
     def action(self) -> Optional[str]:
         """
         The event itself
         """
-        return self._action
+        return self.payload.get("se_ac")
 
     @action.setter
     def action(self, value: Optional[str]):
-        self._action = value
-        self.payload.add("se_ac", self._action)
+        self.payload.add("se_ac", value)
 
     @property
     def label(self) -> Optional[str]:
         """
         Refer to the object the action is performed on
         """
-        return self._label
+        return self.payload.get("se_la")
 
     @label.setter
     def label(self, value: Optional[str]):
-        self._label = value
-        self.payload.add("se_la", self._label)
+        self.payload.add("se_la", value)
 
     @property
     def property_(self) -> Optional[str]:
         """
         Property associated with either the action or the object
         """
-        return self._property_
+        return self.payload.get("se_pr")
 
     @property_.setter
     def property_(self, value: Optional[str]):
-        self._property_ = value
-        self.payload.add("se_pr", self._property_)
+        self.payload.add("se_pr", value)
 
     @property
     def value(self) -> Optional[int]:
         """
         A value associated with the user action
         """
-        return self._value
+        return self.payload.get("se_va")
 
     @value.setter
     def value(self, value: Optional[int]):
-        self._value = value
-        self.payload.add("se_va", self._value)
+        self.payload.add("se_va", value)

--- a/snowplow_tracker/events/structured_event.py
+++ b/snowplow_tracker/events/structured_event.py
@@ -18,6 +18,7 @@ from snowplow_tracker.events.event import Event
 from typing import Optional, List
 from snowplow_tracker.subject import Subject
 from snowplow_tracker.self_describing_json import SelfDescribingJson
+from snowplow_tracker.contracts import non_empty_string
 
 
 class StructuredEvent(Event):
@@ -84,6 +85,7 @@ class StructuredEvent(Event):
 
     @category.setter
     def category(self, value: Optional[str]):
+        non_empty_string(value)
         self.payload.add("se_ca", value)
 
     @property
@@ -95,6 +97,7 @@ class StructuredEvent(Event):
 
     @action.setter
     def action(self, value: Optional[str]):
+        non_empty_string(value)
         self.payload.add("se_ac", value)
 
     @property

--- a/snowplow_tracker/self_describing_json.py
+++ b/snowplow_tracker/self_describing_json.py
@@ -19,12 +19,22 @@ import json
 from typing import Union
 
 from snowplow_tracker.typing import PayloadDict, PayloadDictList
+from snowplow_tracker.contracts import non_empty_string
 
 
 class SelfDescribingJson(object):
     def __init__(self, schema: str, data: Union[PayloadDict, PayloadDictList]) -> None:
         self.schema = schema
         self.data = data
+
+    @property
+    def schema(self) -> str:
+        return self._schema
+
+    @schema.setter
+    def schema(self, value: str):
+        non_empty_string(value)
+        self._schema = value
 
     def to_json(self) -> PayloadDict:
         return {"schema": self.schema, "data": self.data}

--- a/snowplow_tracker/snowplow.py
+++ b/snowplow_tracker/snowplow.py
@@ -85,8 +85,8 @@ class Snowplow:
         )
 
         tracker = Tracker(
-            emitters=emitter,
             namespace=namespace,
+            emitters=emitter,
             app_id=app_id,
             subject=subject,
             encode_base64=tracker_config.encode_base64,

--- a/snowplow_tracker/snowplow.py
+++ b/snowplow_tracker/snowplow.py
@@ -85,7 +85,7 @@ class Snowplow:
         )
 
         tracker = Tracker(
-            emitter,
+            emitters=emitter,
             namespace=namespace,
             app_id=app_id,
             subject=subject,

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -161,7 +161,7 @@ class IntegrationTest(unittest.TestCase):
             "namespace", [get_emitter], default_subject, encode_base64=False
         )
         with HTTMock(pass_response_content):
-            t.track_mobile_screen_view("534", "Game HUD 2")
+            t.track_mobile_screen_view(id_="534", name="Game HUD 2")
         expected_fields = {"e": "ue"}
         for key in expected_fields:
             self.assertEqual(

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -522,7 +522,6 @@ class IntegrationTest(unittest.TestCase):
             t.track_struct_event("Test", "A")  # 483 bytes. Send
             t.track_struct_event("Test", "AA")  # 162
 
-        print(querystrings[-1]["data"])
         self.assertEqual(len(querystrings[-1]["data"]), 3)
         self.assertEqual(default_emitter.bytes_queued, 156 + len(_version.__version__))
 
@@ -551,7 +550,7 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(actual_a, unicode_a)
 
         uepr_string = unquote_plus(from_querystring("ue_pr", querystrings[-1]))
-        actual_b = json.loads(uepr_string)["data"]["data"]["id"]
+        actual_b = json.loads(uepr_string)["data"]["data"]["name"]
         self.assertEqual(actual_b, unicode_b)
 
     def test_unicode_post(self) -> None:
@@ -574,5 +573,5 @@ class IntegrationTest(unittest.TestCase):
         self.assertEqual(in_test_ctx, unicode_a)
 
         sv_event = querystrings[-1]
-        in_uepr_name = json.loads(sv_event["data"][0]["ue_pr"])["data"]["data"]["id"]
+        in_uepr_name = json.loads(sv_event["data"][0]["ue_pr"])["data"]["data"]["name"]
         self.assertEqual(in_uepr_name, unicode_b)

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -513,18 +513,18 @@ class IntegrationTest(unittest.TestCase):
 
     def test_bytelimit(self) -> None:
         default_emitter = emitters.Emitter(
-            "localhost", protocol="http", port=80, batch_size=5, byte_limit=450
+            "localhost", protocol="http", port=80, batch_size=5, byte_limit=483
         )
         t = tracker.Tracker("namespace", default_emitter, default_subject)
         with HTTMock(pass_post_response_content):
-            t.track_struct_event("Test", "A")  # 150 bytes
-            t.track_struct_event("Test", "A")  # 300 bytes
-            t.track_struct_event("Test", "A")  # 450 bytes. Send
-            t.track_struct_event("Test", "AA")  # 151
+            t.track_struct_event("Test", "A")  # 161 bytes
+            t.track_struct_event("Test", "A")  # 322 bytes
+            t.track_struct_event("Test", "A")  # 483 bytes. Send
+            t.track_struct_event("Test", "AA")  # 162
 
         print(querystrings[-1]["data"])
         self.assertEqual(len(querystrings[-1]["data"]), 3)
-        self.assertEqual(default_emitter.bytes_queued, 145 + len(_version.__version__))
+        self.assertEqual(default_emitter.bytes_queued, 156 + len(_version.__version__))
 
     def test_unicode_get(self) -> None:
         t = tracker.Tracker(

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -113,6 +113,7 @@ class IntegrationTest(unittest.TestCase):
                     {"sku": "pbz0026", "price": 20, "quantity": 1},
                     {"sku": "pbz0038", "price": 15, "quantity": 1},
                 ],
+                tstamp=1399021242240,
             )
 
         expected_fields = {
@@ -512,16 +513,18 @@ class IntegrationTest(unittest.TestCase):
 
     def test_bytelimit(self) -> None:
         default_emitter = emitters.Emitter(
-            "localhost", protocol="http", port=80, batch_size=5, byte_limit=483
+            "localhost", protocol="http", port=80, batch_size=5, byte_limit=450
         )
         t = tracker.Tracker("namespace", default_emitter, default_subject)
         with HTTMock(pass_post_response_content):
-            t.track_struct_event("Test", "A")  # 161 bytes
-            t.track_struct_event("Test", "A")  # 322 bytes
-            t.track_struct_event("Test", "A")  # 483 bytes. Send
-            t.track_struct_event("Test", "AA")  # 162
+            t.track_struct_event("Test", "A")  # 150 bytes
+            t.track_struct_event("Test", "A")  # 300 bytes
+            t.track_struct_event("Test", "A")  # 450 bytes. Send
+            t.track_struct_event("Test", "AA")  # 151
+
+        print(querystrings[-1]["data"])
         self.assertEqual(len(querystrings[-1]["data"]), 3)
-        self.assertEqual(default_emitter.bytes_queued, 156 + len(_version.__version__))
+        self.assertEqual(default_emitter.bytes_queued, 145 + len(_version.__version__))
 
     def test_unicode_get(self) -> None:
         t = tracker.Tracker(

--- a/snowplow_tracker/test/integration/test_integration.py
+++ b/snowplow_tracker/test/integration/test_integration.py
@@ -105,8 +105,8 @@ class IntegrationTest(unittest.TestCase):
         t = tracker.Tracker("namespace", [get_emitter], default_subject)
         with HTTMock(pass_response_content):
             t.track_ecommerce_transaction(
-                "6a8078be",
-                35,
+                order_id="6a8078be",
+                total_value=35,
                 city="London",
                 currency="GBP",
                 items=[

--- a/snowplow_tracker/test/unit/test_event.py
+++ b/snowplow_tracker/test/unit/test_event.py
@@ -33,39 +33,34 @@ class TestEvent(unittest.TestCase):
         self.assertEqual(event.payload.nv_pairs, {})
 
     def test_build_payload(self):
-        event = Event()
         event_subject = Subject()
-        payload = event.build_payload(event_subject, None, None, None, None)
+        event = Event(event_subject=event_subject)
+        payload = event.build_payload(encode_base64=None, json_encoder=None)
 
         self.assertEqual(payload.nv_pairs, {"p": "pc"})
 
     def test_build_payload_tstamp(self):
-        event = Event()
         event_subject = Subject()
-
         tstamp = 1399021242030
+
+        event = Event(event_subject=event_subject, tstamp=tstamp)
+
         payload = event.build_payload(
-            event_subject=event_subject,
-            context=None,
             json_encoder=None,
             encode_base64=None,
-            tstamp=tstamp,
         )
 
         self.assertEqual(payload.nv_pairs, {"p": "pc", "ttm": 1399021242030})
 
     def test_build_payload_context(self):
-        event = Event()
         event_subject = Subject()
-
         context = SelfDescribingJson("test.context.schema", {"user": "tester"})
         event_context = [context]
+        event = Event(event_subject=event_subject, context=event_context)
+
         payload = event.build_payload(
-            event_subject=event_subject,
-            context=event_context,
             json_encoder=None,
             encode_base64=False,
-            tstamp=None,
         )
 
         expected_context = {

--- a/snowplow_tracker/test/unit/test_event.py
+++ b/snowplow_tracker/test/unit/test_event.py
@@ -43,7 +43,7 @@ class TestEvent(unittest.TestCase):
         event_subject = Subject()
         tstamp = 1399021242030
 
-        event = Event(event_subject=event_subject, tstamp=tstamp)
+        event = Event(event_subject=event_subject, true_timestamp=tstamp)
 
         payload = event.build_payload(
             json_encoder=None,

--- a/snowplow_tracker/test/unit/test_event.py
+++ b/snowplow_tracker/test/unit/test_event.py
@@ -1,0 +1,77 @@
+# """
+#     test_event.py
+
+#     Copyright (c) 2013-2023 Snowplow Analytics Ltd. All rights reserved.
+
+#     This program is licensed to you under the Apache License Version 2.0,
+#     and you may not use this file except in compliance with the Apache License
+#     Version 2.0. You may obtain a copy of the Apache License Version 2.0 at
+#     http://www.apache.org/licenses/LICENSE-2.0.
+
+#     Unless required by applicable law or agreed to in writing,
+#     software distributed under the Apache License Version 2.0 is distributed on
+#     an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#     express or implied. See the Apache License Version 2.0 for the specific
+#     language governing permissions and limitations there under.
+# """
+
+import json
+import unittest
+from snowplow_tracker.events import Event
+from snowplow_tracker.subject import Subject
+from snowplow_tracker.self_describing_json import SelfDescribingJson
+
+CONTEXT_SCHEMA = "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-1"
+
+
+class TestEvent(unittest.TestCase):
+    def setUp(self) -> None:
+        pass
+
+    def test_init(self):
+        event = Event()
+        self.assertEqual(event.pb.nv_pairs, {})
+
+    def test_build_payload(self):
+        event = Event()
+        event_subject = Subject()
+        pb = event.build_payload(event_subject, None, None, None, None)
+
+        self.assertEqual(pb.nv_pairs, {"p": "pc"})
+
+    def test_build_payload_tstamp(self):
+        event = Event()
+        event_subject = Subject()
+
+        tstamp = 1399021242030
+        pb = event.build_payload(
+            event_subject=event_subject,
+            context=None,
+            json_encoder=None,
+            encode_base64=None,
+            tstamp=tstamp,
+        )
+
+        self.assertEqual(pb.nv_pairs, {"p": "pc", "ttm": 1399021242030})
+
+    def test_build_payload_context(self):
+        event = Event()
+        event_subject = Subject()
+
+        context = SelfDescribingJson("test.context.schema", {"user": "tester"})
+        event_context = [context]
+        pb = event.build_payload(
+            event_subject=event_subject,
+            context=event_context,
+            json_encoder=None,
+            encode_base64=False,
+            tstamp=None,
+        )
+
+        expected_context = {
+            "schema": CONTEXT_SCHEMA,
+            "data": [{"schema": "test.context.schema", "data": {"user": "tester"}}],
+        }
+        actual_context = json.loads(pb.nv_pairs["co"])
+
+        self.assertDictEqual(actual_context, expected_context)

--- a/snowplow_tracker/test/unit/test_event.py
+++ b/snowplow_tracker/test/unit/test_event.py
@@ -30,21 +30,21 @@ class TestEvent(unittest.TestCase):
 
     def test_init(self):
         event = Event()
-        self.assertEqual(event.pb.nv_pairs, {})
+        self.assertEqual(event.payload.nv_pairs, {})
 
     def test_build_payload(self):
         event = Event()
         event_subject = Subject()
-        pb = event.build_payload(event_subject, None, None, None, None)
+        payload = event.build_payload(event_subject, None, None, None, None)
 
-        self.assertEqual(pb.nv_pairs, {"p": "pc"})
+        self.assertEqual(payload.nv_pairs, {"p": "pc"})
 
     def test_build_payload_tstamp(self):
         event = Event()
         event_subject = Subject()
 
         tstamp = 1399021242030
-        pb = event.build_payload(
+        payload = event.build_payload(
             event_subject=event_subject,
             context=None,
             json_encoder=None,
@@ -52,7 +52,7 @@ class TestEvent(unittest.TestCase):
             tstamp=tstamp,
         )
 
-        self.assertEqual(pb.nv_pairs, {"p": "pc", "ttm": 1399021242030})
+        self.assertEqual(payload.nv_pairs, {"p": "pc", "ttm": 1399021242030})
 
     def test_build_payload_context(self):
         event = Event()
@@ -60,7 +60,7 @@ class TestEvent(unittest.TestCase):
 
         context = SelfDescribingJson("test.context.schema", {"user": "tester"})
         event_context = [context]
-        pb = event.build_payload(
+        payload = event.build_payload(
             event_subject=event_subject,
             context=event_context,
             json_encoder=None,
@@ -72,6 +72,6 @@ class TestEvent(unittest.TestCase):
             "schema": CONTEXT_SCHEMA,
             "data": [{"schema": "test.context.schema", "data": {"user": "tester"}}],
         }
-        actual_context = json.loads(pb.nv_pairs["co"])
+        actual_context = json.loads(payload.nv_pairs["co"])
 
         self.assertDictEqual(actual_context, expected_context)

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -1188,7 +1188,6 @@ class TestTracker(unittest.TestCase):
         }
 
         callArgs = mok_track_unstruct.call_args_list[0][1]
-        print(callArgs)
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
@@ -1209,10 +1208,10 @@ class TestTracker(unittest.TestCase):
             json_encoder=t.json_encoder,
         ).nv_pairs
 
-        t.track_mobile_screen_view(screen_view)
+        t.track(screen_view)
 
         self.assertEqual(mok_track.call_count, 1)
-        complete_args_dict = mok_track.call_args_list[0][1]
+        complete_args_dict = mok_track.call_args_list[0][0]
         self.assertEqual(len(complete_args_dict), 1)
         actual_ue_pr = json.loads(actual_pairs["ue_pr"])
 

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -767,11 +767,11 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertIs(callArgs[1][0], ctx)
-        self.assertEqual(callArgs[2], evTstamp)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertIs(callArgs["context"][0], ctx)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_link_click_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -791,11 +791,11 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertTrue(callArgs[1] is None)
-        self.assertTrue(callArgs[2] is None)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertTrue(callArgs["context"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_add_to_cart(self, mok_track_unstruct: Any) -> None:
@@ -831,11 +831,11 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertIs(callArgs[1][0], ctx)
-        self.assertEqual(callArgs[2], evTstamp)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertIs(callArgs["context"][0], ctx)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_add_to_cart_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -853,11 +853,11 @@ class TestTracker(unittest.TestCase):
             "data": {"sku": "sku1234", "quantity": 1},
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertTrue(callArgs[1] is None)
-        self.assertTrue(callArgs[2] is None)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertTrue(callArgs["context"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_remove_from_cart(self, mok_track_unstruct: Any) -> None:
@@ -893,11 +893,11 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertIs(callArgs[1][0], ctx)
-        self.assertEqual(callArgs[2], evTstamp)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertIs(callArgs["context"][0], ctx)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_remove_from_cart_optional_none(
@@ -917,11 +917,11 @@ class TestTracker(unittest.TestCase):
             "data": {"sku": "sku1234", "quantity": 1},
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertTrue(callArgs[1] is None)
-        self.assertTrue(callArgs[2] is None)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertTrue(callArgs["context"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_change(self, mok_track_unstruct: Any) -> None:
@@ -957,11 +957,11 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertIs(callArgs[1][0], ctx)
-        self.assertEqual(callArgs[2], evTstamp)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertIs(callArgs["context"][0], ctx)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_change_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -983,11 +983,11 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertTrue(callArgs[1] is None)
-        self.assertTrue(callArgs[2] is None)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertTrue(callArgs["context"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit(self, mok_track_unstruct: Any) -> None:
@@ -1025,11 +1025,11 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertIs(callArgs[1][0], ctx)
-        self.assertEqual(callArgs[2], evTstamp)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertIs(callArgs["context"][0], ctx)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_invalid_element_type(
@@ -1100,11 +1100,11 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertIs(callArgs[1][0], ctx)
-        self.assertEqual(callArgs[2], evTstamp)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertIs(callArgs["context"][0], ctx)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -1118,11 +1118,11 @@ class TestTracker(unittest.TestCase):
 
         expected = {"schema": FORM_SUBMIT_SCHEMA, "data": {"formId": "testFormId"}}
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertTrue(callArgs[1] is None)
-        self.assertTrue(callArgs[2] is None)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertTrue(callArgs["context"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_empty_elems(self, mok_track_unstruct: Any) -> None:
@@ -1136,9 +1136,9 @@ class TestTracker(unittest.TestCase):
 
         expected = {"schema": FORM_SUBMIT_SCHEMA, "data": {"formId": "testFormId"}}
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_site_search(self, mok_track_unstruct: Any) -> None:
@@ -1165,11 +1165,12 @@ class TestTracker(unittest.TestCase):
             },
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
+
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertIs(callArgs[1][0], ctx)
-        self.assertEqual(callArgs[2], evTstamp)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertIs(callArgs["context"][0], ctx)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_site_search_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -1186,11 +1187,12 @@ class TestTracker(unittest.TestCase):
             "data": {"terms": ["track", "search"]},
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
+        print(callArgs)
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertTrue(callArgs[1] is None)
-        self.assertTrue(callArgs[2] is None)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertTrue(callArgs["context"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track")
     def test_track_mobile_screen_view(self, mok_track: Any) -> None:
@@ -1241,8 +1243,8 @@ class TestTracker(unittest.TestCase):
             "data": {"name": "screenName", "id": "screenId"},
         }
 
-        callArgs = mok_track_unstruct.call_args_list[0][0]
+        callArgs = mok_track_unstruct.call_args_list[0][1]
         self.assertEqual(len(callArgs), 4)
-        self.assertDictEqual(callArgs[0].to_json(), expected)
-        self.assertIs(callArgs[1][0], ctx)
-        self.assertEqual(callArgs[2], evTstamp)
+        self.assertDictEqual(callArgs["event_json"].to_json(), expected)
+        self.assertIs(callArgs["context"][0], ctx)
+        self.assertEqual(callArgs["tstamp"], evTstamp)

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -381,7 +381,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(complete_args_dict), 4)
 
         # payload
-        actual_payload_arg = complete_args_dict["event"].pb
+        actual_payload_arg = complete_args_dict["event"].payload
         actual_pairs = actual_payload_arg.nv_pairs
         actual_ue_pr = json.loads(actual_pairs["ue_pr"])
         # context
@@ -418,7 +418,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(complete_args_dict), 4)
 
         # payload
-        actual_payload_arg = complete_args_dict["event"].pb
+        actual_payload_arg = complete_args_dict["event"].payload
         actualPairs = actual_payload_arg.nv_pairs
         actualUePr = json.loads(actualPairs["ue_pr"])
         # context
@@ -450,7 +450,7 @@ class TestTracker(unittest.TestCase):
         complete_args_dict = mok_track.call_args_list[0][1]
         self.assertEqual(len(complete_args_dict), 4)
 
-        actual_payload_arg = complete_args_dict["event"].pb
+        actual_payload_arg = complete_args_dict["event"].payload
         actual_pairs = actual_payload_arg.nv_pairs
         self.assertTrue("ue_px" in actual_pairs.keys())
 
@@ -477,7 +477,7 @@ class TestTracker(unittest.TestCase):
         complete_args_dict = mok_track.call_args_list[0][1]
         self.assertEqual(len(complete_args_dict), 4)
 
-        actual_payload_arg = complete_args_dict["event"].pb
+        actual_payload_arg = complete_args_dict["event"].payload
         actual_context_arg = complete_args_dict["context"]
         actual_tstamp_arg = complete_args_dict["tstamp"]
         actual_pairs = actual_payload_arg.nv_pairs
@@ -515,7 +515,7 @@ class TestTracker(unittest.TestCase):
         complete_args_dict = mok_track.call_args_list[0][1]
         self.assertEqual(len(complete_args_dict), 4)
 
-        actual_payload_arg = complete_args_dict["event"].pb
+        actual_payload_arg = complete_args_dict["event"].payload
         actual_context_arg = complete_args_dict["context"]
         actual_tstamp_arg = complete_args_dict["tstamp"]
         actualPairs = actual_payload_arg.nv_pairs
@@ -555,7 +555,7 @@ class TestTracker(unittest.TestCase):
         complete_args_dict = mok_track.call_args_list[0][1]
         self.assertEqual(len(complete_args_dict), 4)
 
-        actual_payload_arg = complete_args_dict["event"].pb
+        actual_payload_arg = complete_args_dict["event"].payload
         actual_context_arg = complete_args_dict["context"]
         actual_tstamp_arg = complete_args_dict["tstamp"]
         actual_pairs = actual_payload_arg.nv_pairs
@@ -599,7 +599,7 @@ class TestTracker(unittest.TestCase):
         complete_args_list = mok_track.call_args_list[0][1]
         self.assertEqual(len(complete_args_list), 4)
 
-        actual_payload_arg = complete_args_list["event"].pb
+        actual_payload_arg = complete_args_list["event"].payload
         actual_context_arg = complete_args_list["context"]
         actual_tstamp_arg = complete_args_list["tstamp"]
         actual_pairs = actual_payload_arg.nv_pairs
@@ -645,7 +645,7 @@ class TestTracker(unittest.TestCase):
         completeArgsList = mok_track.call_args_list[0][1]
         self.assertEqual(len(completeArgsList), 4)
 
-        actualPayloadArg = completeArgsList["event"].pb
+        actualPayloadArg = completeArgsList["event"].payload
         actualContextArg = completeArgsList["context"]
         actualTstampArg = completeArgsList["tstamp"]
         actualPairs = actualPayloadArg.nv_pairs
@@ -704,7 +704,7 @@ class TestTracker(unittest.TestCase):
         firstCallArgsList = callCompleteArgsList[0][1]
         self.assertEqual(len(firstCallArgsList), 4)
 
-        actualPayloadArg = firstCallArgsList["event"].pb
+        actualPayloadArg = firstCallArgsList["event"].payload
         actualContextArg = firstCallArgsList["context"]
         actualTstampArg = firstCallArgsList["tstamp"]
         actualPairs = actualPayloadArg.nv_pairs

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -274,7 +274,7 @@ class TestTracker(unittest.TestCase):
         t = Tracker("namespace", e)
         s = Subject()
         time_in_millis = 100010001000
-        event = Event(tstamp=time_in_millis, event_subject=s)
+        event = Event(true_timestamp=time_in_millis, event_subject=s)
 
         payload = t.complete_payload(event=event).nv_pairs
 
@@ -771,7 +771,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["tstamp"], evTstamp)
+        self.assertEqual(callArgs["true_timestamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_link_click_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -795,7 +795,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["tstamp"] is None)
+        self.assertTrue(callArgs["true_timestamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_add_to_cart(self, mok_track_unstruct: Any) -> None:
@@ -835,7 +835,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["tstamp"], evTstamp)
+        self.assertEqual(callArgs["true_timestamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_add_to_cart_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -857,7 +857,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["tstamp"] is None)
+        self.assertTrue(callArgs["true_timestamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_remove_from_cart(self, mok_track_unstruct: Any) -> None:
@@ -897,7 +897,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["tstamp"], evTstamp)
+        self.assertEqual(callArgs["true_timestamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_remove_from_cart_optional_none(
@@ -921,7 +921,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["tstamp"] is None)
+        self.assertTrue(callArgs["true_timestamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_change(self, mok_track_unstruct: Any) -> None:
@@ -961,7 +961,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["tstamp"], evTstamp)
+        self.assertEqual(callArgs["true_timestamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_change_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -987,7 +987,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["tstamp"] is None)
+        self.assertTrue(callArgs["true_timestamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit(self, mok_track_unstruct: Any) -> None:
@@ -1029,7 +1029,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["tstamp"], evTstamp)
+        self.assertEqual(callArgs["true_timestamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_invalid_element_type(
@@ -1104,7 +1104,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["tstamp"], evTstamp)
+        self.assertEqual(callArgs["true_timestamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -1122,7 +1122,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["tstamp"] is None)
+        self.assertTrue(callArgs["true_timestamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_empty_elems(self, mok_track_unstruct: Any) -> None:
@@ -1170,7 +1170,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["tstamp"], evTstamp)
+        self.assertEqual(callArgs["true_timestamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_site_search_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -1192,7 +1192,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["tstamp"] is None)
+        self.assertTrue(callArgs["true_timestamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track")
     def test_track_mobile_screen_view(self, mok_track: Any) -> None:
@@ -1247,4 +1247,4 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["tstamp"], evTstamp)
+        self.assertEqual(callArgs["true_timestamp"], evTstamp)

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -131,15 +131,8 @@ class Tracker:
     ) -> Optional[str]:
         """
         Send the event payload to a emitter. Returns the tracked event ID.
-
         :param  event:           Event
         :type   event:           events.Event
-        :param  context:         Custom context for the event
-        :type   context:         context_array | None
-        :param  tstamp:          Optional event timestamp in milliseconds
-        :type   tstamp:          int | float | None
-        :param  event_subject:   Optional per event subject
-        :type   event_subject:   subject | None
         :rtype:                  String
         """
 

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -890,7 +890,7 @@ class Tracker:
         :rtype:                  Tracker
         """
 
-        sd = SelfDescribing(event_json, self.encode_base64, self.json_encoder)
+        sd = SelfDescribing(event_json)
         self.track(
             event=sd, context=context, tstamp=tstamp, event_subject=event_subject
         )

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -205,6 +205,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
+        warn(
+            "track_page_view will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(page_url)
 
         pv = PageView(page_url=page_url)
@@ -253,6 +258,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
+        warn(
+            "track_page_ping will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(page_url)
 
         pp = PagePing(page_url)
@@ -299,6 +309,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
+        warn(
+            "track_link_click will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(target_url)
 
         properties = {}
@@ -470,6 +485,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
+        warn(
+            "track_form_change will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(form_id)
         one_of(node_name, FORM_NODE_NAMES)
         if type_ is not None:
@@ -516,6 +536,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
+        warn(
+            "track_form_submit will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(form_id)
         for element in elements or []:
             form_element(element)
@@ -561,6 +586,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
+        warn(
+            "track_site_search will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty(terms)
 
         properties = {}
@@ -799,6 +829,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
+        warn(
+            "track_mobile_screen_view will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if id_ is None:
             id_ = self.get_uuid()
 
@@ -848,6 +883,11 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
+        warn(
+            "track_struct_event will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         non_empty_string(category)
         non_empty_string(action)
 
@@ -880,7 +920,11 @@ class Tracker:
         :type   event_subject:   subject | None
         :rtype:                  Tracker
         """
-
+        warn(
+            "track_self_describing_event will be deprecated in future versions. Please use the new Event API to create events.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         sd = SelfDescribing(event_json)
         self.track(
             event=sd, context=context, tstamp=tstamp, event_subject=event_subject

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -34,7 +34,7 @@ from snowplow_tracker.constants import (
 from snowplow_tracker.events import (
     Event,
     PagePing,
-    Pageview,
+    PageView,
     SelfDescribing,
     StructEvent,
 )
@@ -206,7 +206,7 @@ class Tracker:
         """
         non_empty_string(page_url)
 
-        pv = Pageview(page_url=page_url)
+        pv = PageView(page_url=page_url)
         pv.page_title = page_title
         pv.page_url = page_url
         pv.referrer = referrer

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -252,7 +252,7 @@ class Tracker:
         pp = PagePing(
             page_url=page_url,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         pp.page_title = page_title
@@ -323,7 +323,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         return self
@@ -389,7 +389,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         return self
@@ -455,7 +455,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         return self
@@ -523,7 +523,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         return self
@@ -578,7 +578,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         return self
@@ -634,7 +634,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         return self
@@ -688,7 +688,7 @@ class Tracker:
 
         fin_subject = event_subject if event_subject is not None else self.subject
 
-        event = Event(event_subject=fin_subject, context=context, tstamp=tstamp)
+        event = Event(event_subject=fin_subject, context=context, true_timestamp=tstamp)
         event.payload.add("e", "ti")
         event.payload.add("ti_id", order_id)
         event.payload.add("ti_sk", sku)
@@ -755,7 +755,7 @@ class Tracker:
 
         fin_subject = event_subject if event_subject is not None else self.subject
 
-        event = Event(event_subject=fin_subject, context=context, tstamp=tstamp)
+        event = Event(event_subject=fin_subject, context=context, true_timestamp=tstamp)
         event.payload.add("e", "tr")
         event.payload.add("tr_id", order_id)
         event.payload.add("tr_tt", total_value)
@@ -825,7 +825,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         return self
@@ -876,14 +876,7 @@ class Tracker:
         if id_ is None:
             id_ = self.get_uuid()
 
-        sv = ScreenView(event_subject=fin_subject, context=context, tstamp=tstamp)
-        sv.id_ = id_
-        sv.name = name
-        sv.type = type
-        sv.previous_name = previous_name
-        sv.previous_id = previous_id
-        sv.previous_type = previous_type
-        sv.transition_type = transition_type
+            true_timestamp=tstamp,
 
         self.track(event=sv)
         return self
@@ -933,7 +926,7 @@ class Tracker:
             category=category,
             action=action,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         se.label = label
@@ -974,7 +967,7 @@ class Tracker:
         sd = SelfDescribing(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         self.track(
@@ -1013,7 +1006,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            tstamp=tstamp,
+            true_timestamp=tstamp,
             event_subject=fin_subject,
         )
         return self

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -36,7 +36,7 @@ from snowplow_tracker.events import (
     PagePing,
     PageView,
     SelfDescribing,
-    StructEvent,
+    StructuredEvent,
     ScreenView,
 )
 from snowplow_tracker.typing import (
@@ -929,7 +929,7 @@ class Tracker:
         non_empty_string(action)
         fin_subject = event_subject if event_subject is not None else self.subject
 
-        se = StructEvent(
+        se = StructuredEvent(
             category=category,
             action=action,
             context=context,

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -153,6 +153,7 @@ class Tracker:
         payload = event.build_payload(
             encode_base64=self.encode_base64,
             json_encoder=self.json_encoder,
+            subject=self.subject,
         )
 
         payload.add("eid", Tracker.get_uuid())

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -145,7 +145,7 @@ class Tracker:
         :rtype:                  String
         """
 
-        pb = self.complete_payload(
+        payload = self.complete_payload(
             event=event,
             tstamp=tstamp,
             event_subject=event_subject,
@@ -153,10 +153,10 @@ class Tracker:
         )
 
         for emitter in self.emitters:
-            emitter.input(pb.nv_pairs)
+            emitter.input(payload.nv_pairs)
 
-        if "eid" in pb.nv_pairs.keys():
-            return pb.nv_pairs["eid"]
+        if "eid" in payload.nv_pairs.keys():
+            return payload.nv_pairs["eid"]
 
     def complete_payload(
         self,
@@ -166,7 +166,7 @@ class Tracker:
         tstamp: Optional[float],
     ) -> payload.Payload:
         fin_subject = event_subject if event_subject is not None else self.subject
-        pb = event.build_payload(
+        payload = event.build_payload(
             encode_base64=self.encode_base64,
             json_encoder=self.json_encoder,
             tstamp=tstamp,
@@ -174,11 +174,11 @@ class Tracker:
             context=context,
         )
 
-        pb.add("eid", Tracker.get_uuid())
-        pb.add("dtm", Tracker.get_timestamp())
-        pb.add_dict(self.standard_nv_pairs)
+        payload.add("eid", Tracker.get_uuid())
+        payload.add("dtm", Tracker.get_timestamp())
+        payload.add_dict(self.standard_nv_pairs)
 
-        return pb
+        return payload
 
     def track_page_view(
         self,
@@ -626,14 +626,14 @@ class Tracker:
         non_empty_string(sku)
 
         event = Event()
-        event.pb.add("e", "ti")
-        event.pb.add("ti_id", order_id)
-        event.pb.add("ti_sk", sku)
-        event.pb.add("ti_nm", name)
-        event.pb.add("ti_ca", category)
-        event.pb.add("ti_pr", price)
-        event.pb.add("ti_qu", quantity)
-        event.pb.add("ti_cu", currency)
+        event.payload.add("e", "ti")
+        event.payload.add("ti_id", order_id)
+        event.payload.add("ti_sk", sku)
+        event.payload.add("ti_nm", name)
+        event.payload.add("ti_ca", category)
+        event.payload.add("ti_pr", price)
+        event.payload.add("ti_qu", quantity)
+        event.payload.add("ti_cu", currency)
 
         self.track(
             event=event, event_subject=event_subject, context=context, tstamp=tstamp
@@ -693,16 +693,16 @@ class Tracker:
         non_empty_string(order_id)
 
         event = Event()
-        event.pb.add("e", "tr")
-        event.pb.add("tr_id", order_id)
-        event.pb.add("tr_tt", total_value)
-        event.pb.add("tr_af", affiliation)
-        event.pb.add("tr_tx", tax_value)
-        event.pb.add("tr_sh", shipping)
-        event.pb.add("tr_ci", city)
-        event.pb.add("tr_st", state)
-        event.pb.add("tr_co", country)
-        event.pb.add("tr_cu", currency)
+        event.payload.add("e", "tr")
+        event.payload.add("tr_id", order_id)
+        event.payload.add("tr_tt", total_value)
+        event.payload.add("tr_af", affiliation)
+        event.payload.add("tr_tx", tax_value)
+        event.payload.add("tr_sh", shipping)
+        event.payload.add("tr_ci", city)
+        event.payload.add("tr_st", state)
+        event.payload.add("tr_co", country)
+        event.payload.add("tr_cu", currency)
 
         tstamp = Tracker.get_timestamp(tstamp)
 

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -196,11 +196,13 @@ class Tracker:
         fin_subject = event_subject if event_subject is not None else self.subject
 
         pv = PageView(
-            page_url=page_url, event_subject=fin_subject, context=context, tstamp=tstamp
+            page_url=page_url,
+            page_title=page_title,
+            referrer=referrer,
+            event_subject=fin_subject,
+            context=context,
+            true_timestamp=tstamp,
         )
-        pv.page_title = page_title
-        pv.page_url = page_url
-        pv.referrer = referrer
 
         self.track(event=pv)
         return self
@@ -252,17 +254,16 @@ class Tracker:
 
         pp = PagePing(
             page_url=page_url,
+            page_title=page_title,
+            referrer=referrer,
+            min_x=min_x,
+            max_x=max_x,
+            min_y=min_y,
+            max_y=max_y,
             context=context,
             true_timestamp=tstamp,
             event_subject=fin_subject,
         )
-        pp.page_title = page_title
-        pp.page_url = page_url
-        pp.referrer = referrer
-        pp.min_x = min_x
-        pp.max_x = max_x
-        pp.min_y = min_y
-        pp.max_y = max_y
 
         self.track(event=pp)
         return self
@@ -877,7 +878,18 @@ class Tracker:
         if id_ is None:
             id_ = self.get_uuid()
 
+        sv = ScreenView(
+            name=name,
+            id_=id_,
+            type=type,
+            previous_name=previous_name,
+            previous_id=previous_id,
+            previous_type=previous_type,
+            transition_type=transition_type,
+            event_subject=fin_subject,
+            context=context,
             true_timestamp=tstamp,
+        )
 
         self.track(event=sv)
         return self
@@ -926,13 +938,13 @@ class Tracker:
         se = StructuredEvent(
             category=category,
             action=action,
+            label=label,
+            property_=property_,
+            value=value,
             context=context,
             true_timestamp=tstamp,
             event_subject=fin_subject,
         )
-        se.label = label
-        se.property_ = property_
-        se.value = value
         self.track(
             event=se,
         )

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -21,7 +21,7 @@ from typing import Any, Optional, Union, List, Dict, Sequence
 from warnings import warn
 
 from snowplow_tracker import payload, SelfDescribingJson
-from snowplow_tracker import subject as _subject
+from snowplow_tracker.subject import Subject
 from snowplow_tracker.contracts import non_empty_string, one_of, non_empty, form_element
 from snowplow_tracker.constants import (
     VERSION,
@@ -59,7 +59,7 @@ class Tracker:
         self,
         namespace: str,
         emitters: Union[List[EmitterProtocol], EmitterProtocol],
-        subject: Optional[_subject.Subject] = None,
+        subject: Optional[Subject] = None,
         app_id: Optional[str] = None,
         encode_base64: bool = DEFAULT_ENCODE_BASE64,
         json_encoder: Optional[JsonEncoderFunction] = None,
@@ -79,7 +79,7 @@ class Tracker:
         :type  json_encoder:     function | None
         """
         if subject is None:
-            subject = _subject.Subject()
+            subject = Subject()
 
         if type(emitters) is list:
             non_empty(emitters)
@@ -169,7 +169,7 @@ class Tracker:
         referrer: Optional[str] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  page_url:       URL of the viewed page
@@ -218,7 +218,7 @@ class Tracker:
         max_y: Optional[int] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  page_url:       URL of the viewed page
@@ -277,7 +277,7 @@ class Tracker:
         element_content: Optional[str] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  target_url:         Target URL of the link
@@ -340,7 +340,7 @@ class Tracker:
         currency: Optional[str] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  sku:            Item SKU or ID
@@ -406,7 +406,7 @@ class Tracker:
         currency: Optional[str] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  sku:            Item SKU or ID
@@ -472,7 +472,7 @@ class Tracker:
         element_classes: Optional[ElementClasses] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  form_id:            ID attribute of the HTML form
@@ -537,7 +537,7 @@ class Tracker:
         elements: Optional[List[Dict[str, Any]]] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  form_id:        ID attribute of the HTML form
@@ -593,7 +593,7 @@ class Tracker:
         page_results: Optional[int] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  terms:          Search terms
@@ -652,7 +652,7 @@ class Tracker:
         currency: Optional[str] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         This is an internal method called by track_ecommerce_transaction.
@@ -717,7 +717,7 @@ class Tracker:
         items: Optional[List[Dict[str, Any]]] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  order_id:       ID of the eCommerce transaction
@@ -791,7 +791,7 @@ class Tracker:
         id_: Optional[str] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  name:           The name of the screen view event
@@ -843,7 +843,7 @@ class Tracker:
         transition_type: Optional[str] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  name:           The name of the screen view event
@@ -903,7 +903,7 @@ class Tracker:
         value: Optional[float] = None,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  category:       Category of the event
@@ -956,7 +956,7 @@ class Tracker:
         event_json: SelfDescribingJson,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  event_json:      The properties of the event. Has two field:
@@ -995,7 +995,7 @@ class Tracker:
         event_json: SelfDescribingJson,
         context: Optional[List[SelfDescribingJson]] = None,
         tstamp: Optional[float] = None,
-        event_subject: Optional[_subject.Subject] = None,
+        event_subject: Optional[Subject] = None,
     ) -> "Tracker":
         """
         :param  event_json:      The properties of the event. Has two field:
@@ -1042,7 +1042,7 @@ class Tracker:
                     emitter.sync_flush()
         return self
 
-    def set_subject(self, subject: Optional[_subject.Subject]) -> "Tracker":
+    def set_subject(self, subject: Optional[Subject]) -> "Tracker":
         """
         Set the subject of the events fired by the tracker
 

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -187,7 +187,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_page_view will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_page_view will be removed in future versions. Please use the new PageView class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -242,7 +242,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_page_ping will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_page_ping will be removed in future versions. Please use the new PagePing class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -298,7 +298,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_link_click will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_link_click will be removed in future versions. Please use the new SelfDescribing class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -495,7 +495,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_form_change will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_form_change will be removed in future versions. Please use the new SelfDescribing class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -554,7 +554,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_form_submit will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_form_submit will be removed in future versions. Please use the new SelfDescribing class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -612,7 +612,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_site_search will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_site_search will be removed in future versions. Please use the new SelfDescribing class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -806,7 +806,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_screen_view will be deprecated in future versions. Please use track_mobile_screen_view.",
+            "track_screen_view will be removed in future versions. Please use the new ScreenView class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -868,7 +868,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_mobile_screen_view will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_mobile_screen_view will be removed in future versions. Please use the new ScreenView class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -915,7 +915,7 @@ class Tracker:
         :rtype:                 Tracker
         """
         warn(
-            "track_struct_event will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_struct_event will be removed in future versions. Please use the new Structured class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -959,7 +959,7 @@ class Tracker:
         :rtype:                  Tracker
         """
         warn(
-            "track_self_describing_event will be deprecated in future versions. Please use the new Event API to create events.",
+            "track_self_describing_event will be removed in future versions. Please use the new SelfDescribing class to track the event.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -37,6 +37,7 @@ from snowplow_tracker.events import (
     PageView,
     SelfDescribing,
     StructEvent,
+    ScreenView,
 )
 from snowplow_tracker.typing import (
     JsonEncoderFunction,
@@ -798,31 +799,21 @@ class Tracker:
         :type   event_subject:  subject | None
         :rtype:                 Tracker
         """
-        screen_view_properties = {}
-
         if id_ is None:
             id_ = self.get_uuid()
 
-        screen_view_properties["id"] = id_
+        sv = ScreenView()
+        sv.id_ = id_
+        sv.name = name
+        sv.type = type
+        sv.previous_name = previous_name
+        sv.previous_id = previous_id
+        sv.previous_type = previous_type
+        sv.transition_type = transition_type
 
-        if name is not None:
-            screen_view_properties["name"] = name
-        if type is not None:
-            screen_view_properties["type"] = type
-        if previous_name is not None:
-            screen_view_properties["previousName"] = previous_name
-        if previous_id is not None:
-            screen_view_properties["previousId"] = previous_id
-        if previous_type is not None:
-            screen_view_properties["previousType"] = previous_type
-        if transition_type is not None:
-            screen_view_properties["transitionType"] = transition_type
-
-        event_json = SelfDescribingJson(
-            "%s/screen_view/%s/1-0-0" % (MOBILE_SCHEMA_PATH, SCHEMA_TAG),
-            screen_view_properties,
+        self.track(
+            event=sv, event_subject=event_subject, context=context, tstamp=tstamp
         )
-        self.track_self_describing_event(event_json, context, tstamp, event_subject)
         return self
 
     def track_struct_event(

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -27,7 +27,6 @@ from snowplow_tracker.constants import (
     VERSION,
     DEFAULT_ENCODE_BASE64,
     BASE_SCHEMA_PATH,
-    MOBILE_SCHEMA_PATH,
     SCHEMA_TAG,
 )
 
@@ -191,15 +190,12 @@ class Tracker:
             DeprecationWarning,
             stacklevel=2,
         )
-        non_empty_string(page_url)
-
-        fin_subject = event_subject if event_subject is not None else self.subject
 
         pv = PageView(
             page_url=page_url,
             page_title=page_title,
             referrer=referrer,
-            event_subject=fin_subject,
+            event_subject=event_subject,
             context=context,
             true_timestamp=tstamp,
         )
@@ -248,9 +244,6 @@ class Tracker:
             DeprecationWarning,
             stacklevel=2,
         )
-        non_empty_string(page_url)
-
-        fin_subject = event_subject if event_subject is not None else self.subject
 
         pp = PagePing(
             page_url=page_url,
@@ -262,7 +255,7 @@ class Tracker:
             max_y=max_y,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
 
         self.track(event=pp)
@@ -305,8 +298,6 @@ class Tracker:
         )
         non_empty_string(target_url)
 
-        fin_subject = event_subject if event_subject is not None else self.subject
-
         properties = {}
         properties["targetUrl"] = target_url
         if element_id is not None:
@@ -326,7 +317,7 @@ class Tracker:
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         return self
 
@@ -370,8 +361,6 @@ class Tracker:
         )
         non_empty_string(sku)
 
-        fin_subject = event_subject if event_subject is not None else self.subject
-
         properties = {}
         properties["sku"] = sku
         properties["quantity"] = quantity
@@ -392,7 +381,7 @@ class Tracker:
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         return self
 
@@ -436,8 +425,6 @@ class Tracker:
         )
         non_empty_string(sku)
 
-        fin_subject = event_subject if event_subject is not None else self.subject
-
         properties = {}
         properties["sku"] = sku
         properties["quantity"] = quantity
@@ -458,7 +445,7 @@ class Tracker:
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         return self
 
@@ -501,8 +488,6 @@ class Tracker:
             stacklevel=2,
         )
 
-        fin_subject = event_subject if event_subject is not None else self.subject
-
         non_empty_string(form_id)
         one_of(node_name, FORM_NODE_NAMES)
         if type_ is not None:
@@ -526,7 +511,7 @@ class Tracker:
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         return self
 
@@ -561,8 +546,6 @@ class Tracker:
         )
         non_empty_string(form_id)
 
-        fin_subject = event_subject if event_subject is not None else self.subject
-
         for element in elements or []:
             form_element(element)
 
@@ -581,7 +564,7 @@ class Tracker:
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         return self
 
@@ -618,7 +601,6 @@ class Tracker:
             stacklevel=2,
         )
         non_empty(terms)
-        fin_subject = event_subject if event_subject is not None else self.subject
 
         properties = {}
         properties["terms"] = terms
@@ -637,7 +619,7 @@ class Tracker:
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         return self
 
@@ -688,9 +670,9 @@ class Tracker:
         non_empty_string(order_id)
         non_empty_string(sku)
 
-        fin_subject = event_subject if event_subject is not None else self.subject
-
-        event = Event(event_subject=fin_subject, context=context, true_timestamp=tstamp)
+        event = Event(
+            event_subject=event_subject, context=context, true_timestamp=tstamp
+        )
         event.payload.add("e", "ti")
         event.payload.add("ti_id", order_id)
         event.payload.add("ti_sk", sku)
@@ -755,9 +737,9 @@ class Tracker:
         )
         non_empty_string(order_id)
 
-        fin_subject = event_subject if event_subject is not None else self.subject
-
-        event = Event(event_subject=fin_subject, context=context, true_timestamp=tstamp)
+        event = Event(
+            event_subject=event_subject, context=context, true_timestamp=tstamp
+        )
         event.payload.add("e", "tr")
         event.payload.add("tr_id", order_id)
         event.payload.add("tr_tt", total_value)
@@ -811,8 +793,6 @@ class Tracker:
             DeprecationWarning,
             stacklevel=2,
         )
-        fin_subject = event_subject if event_subject is not None else self.subject
-
         screen_view_properties = {}
         if name is not None:
             screen_view_properties["name"] = name
@@ -828,7 +808,7 @@ class Tracker:
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         return self
 
@@ -873,8 +853,6 @@ class Tracker:
             DeprecationWarning,
             stacklevel=2,
         )
-        fin_subject = event_subject if event_subject is not None else self.subject
-
         if id_ is None:
             id_ = self.get_uuid()
 
@@ -886,7 +864,7 @@ class Tracker:
             previous_id=previous_id,
             previous_type=previous_type,
             transition_type=transition_type,
-            event_subject=fin_subject,
+            event_subject=event_subject,
             context=context,
             true_timestamp=tstamp,
         )
@@ -931,10 +909,6 @@ class Tracker:
             DeprecationWarning,
             stacklevel=2,
         )
-        non_empty_string(category)
-        non_empty_string(action)
-        fin_subject = event_subject if event_subject is not None else self.subject
-
         se = StructuredEvent(
             category=category,
             action=action,
@@ -943,7 +917,7 @@ class Tracker:
             value=value,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
 
         self.track(
@@ -976,13 +950,12 @@ class Tracker:
             DeprecationWarning,
             stacklevel=2,
         )
-        fin_subject = event_subject if event_subject is not None else self.subject
 
         sd = SelfDescribing(
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         self.track(
             event=sd,
@@ -1015,13 +988,12 @@ class Tracker:
             DeprecationWarning,
             stacklevel=2,
         )
-        fin_subject = event_subject if event_subject is not None else self.subject
 
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
             true_timestamp=tstamp,
-            event_subject=fin_subject,
+            event_subject=event_subject,
         )
         return self
 

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -280,23 +280,23 @@ class Tracker:
         event_subject: Optional[_subject.Subject] = None,
     ) -> "Tracker":
         """
-        :param  target_url:     Target URL of the link
-        :type   target_url:     non_empty_string
-        :param  element_id:     ID attribute of the HTML element
-        :type   element_id:     string_or_none
+        :param  target_url:         Target URL of the link
+        :type   target_url:         non_empty_string
+        :param  element_id:         ID attribute of the HTML element
+        :type   element_id:         string_or_none
         :param  element_classes:    Classes of the HTML element
         :type   element_classes:    list(str) | tuple(str,\\*) | None
         :param  element_target:     ID attribute of the HTML element
         :type   element_target:     string_or_none
         :param  element_content:    The content of the HTML element
         :type   element_content:    string_or_none
-        :param  context:        Custom context for the event
-        :type   context:        context_array | None
-        :param  tstamp:         Optional event timestamp in milliseconds
-        :type   tstamp:         int | float | None
-        :param  event_subject:  Optional per event subject
-        :type   event_subject:  subject | None
-        :rtype:                 Tracker
+        :param  context:            Custom context for the event
+        :type   context:            context_array | None
+        :param  tstamp:             Optional event timestamp in milliseconds
+        :type   tstamp:             int | float | None
+        :param  event_subject:      Optional per event subject
+        :type   event_subject:      subject | None
+        :rtype:                     Tracker
         """
         warn(
             "track_link_click will be removed in future versions. Please use the new SelfDescribing class to track the event.",
@@ -475,25 +475,25 @@ class Tracker:
         event_subject: Optional[_subject.Subject] = None,
     ) -> "Tracker":
         """
-        :param  form_id:        ID attribute of the HTML form
-        :type   form_id:        non_empty_string
-        :param  element_id:     ID attribute of the HTML element
-        :type   element_id:     string_or_none
-        :param  node_name:      Type of input element
-        :type   node_name:      form_node_name
-        :param  value:          Value of the input element
-        :type   value:          string_or_none
-        :param  type_:          Type of data the element represents
-        :type   type_:          non_empty_string, form_type
+        :param  form_id:            ID attribute of the HTML form
+        :type   form_id:            non_empty_string
+        :param  element_id:         ID attribute of the HTML element
+        :type   element_id:         string_or_none
+        :param  node_name:          Type of input element
+        :type   node_name:          form_node_name
+        :param  value:              Value of the input element
+        :type   value:              string_or_none
+        :param  type_:              Type of data the element represents
+        :type   type_:              non_empty_string, form_type
         :param  element_classes:    Classes of the HTML element
         :type   element_classes:    list(str) | tuple(str,\\*) | None
-        :param  context:        Custom context for the event
-        :type   context:        context_array | None
-        :param  tstamp:         Optional event timestamp in milliseconds
-        :type   tstamp:         int | float | None
-        :param  event_subject:  Optional per event subject
-        :type   event_subject:  subject | None
-        :rtype:                 Tracker
+        :param  context:            Custom context for the event
+        :type   context:            context_array | None
+        :param  tstamp:             Optional event timestamp in milliseconds
+        :type   tstamp:             int | float | None
+        :param  event_subject:      Optional per event subject
+        :type   event_subject:      subject | None
+        :rtype:                     Tracker
         """
         warn(
             "track_form_change will be removed in future versions. Please use the new SelfDescribing class to track the event.",
@@ -658,27 +658,27 @@ class Tracker:
         This is an internal method called by track_ecommerce_transaction.
         It is not for public use.
 
-        :param  order_id:    Order ID
-        :type   order_id:    non_empty_string
-        :param  sku:         Item SKU
-        :type   sku:         non_empty_string
-        :param  price:       Item price
-        :type   price:       int | float
-        :param  quantity:    Item quantity
-        :type   quantity:    int
-        :param  name:        Item name
-        :type   name:        string_or_none
-        :param  category:    Item category
-        :type   category:    string_or_none
-        :param  currency:    The currency the price is expressed in
-        :type   currency:    string_or_none
-        :param  context:     Custom context for the event
-        :type   context:     context_array | None
-        :param  tstamp:      Optional event timestamp in milliseconds
-        :type   tstamp:      int | float | None
+        :param  order_id:       Order ID
+        :type   order_id:       non_empty_string
+        :param  sku:            Item SKU
+        :type   sku:            non_empty_string
+        :param  price:          Item price
+        :type   price:          int | float
+        :param  quantity:       Item quantity
+        :type   quantity:       int
+        :param  name:           Item name
+        :type   name:           string_or_none
+        :param  category:       Item category
+        :type   category:       string_or_none
+        :param  currency:       The currency the price is expressed in
+        :type   currency:       string_or_none
+        :param  context:        Custom context for the event
+        :type   context:        context_array | None
+        :param  tstamp:         Optional event timestamp in milliseconds
+        :type   tstamp:         int | float | None
         :param  event_subject:  Optional per event subject
         :type   event_subject:  subject | None
-        :rtype:              Tracker
+        :rtype:                 Tracker
         """
         warn(
             "track_ecommerce_transaction_item will be deprecated in future versions.",
@@ -834,8 +834,8 @@ class Tracker:
 
     def track_mobile_screen_view(
         self,
+        name: str,
         id_: Optional[str] = None,
-        name: Optional[str] = None,
         type: Optional[str] = None,
         previous_name: Optional[str] = None,
         previous_id: Optional[str] = None,
@@ -846,10 +846,10 @@ class Tracker:
         event_subject: Optional[_subject.Subject] = None,
     ) -> "Tracker":
         """
-        :param  id_:            Screen view ID. This must be of type UUID.
-        :type   id_:            string | None
         :param  name:           The name of the screen view event
         :type   name:           string_or_none
+        :param  id_:            Screen view ID. This must be of type UUID.
+        :type   id_:            string | None
         :param  type:           The type of screen that was viewed e.g feed / carousel.
         :type   type:           string | None
         :param  previous_name:  The name of the previous screen.
@@ -945,6 +945,7 @@ class Tracker:
             true_timestamp=tstamp,
             event_subject=fin_subject,
         )
+
         self.track(
             event=se,
         )


### PR DESCRIPTION
This PR introduces the Event class, which now handles the building of the event payload instead of the tracker. It also introduces Event subclasses for Pageview, Pageping, Struct and SelfDescribing events. 