### PR TITLE
Update payload builder to combine event subjects (close #347)

### DIFF
--- a/examples/tracker_api_example/app.py
+++ b/examples/tracker_api_example/app.py
@@ -31,10 +31,13 @@ def main():
 
     print("Sending events to " + e.endpoint)
 
+    event_subject = Subject()
+    event_subject.set_color_depth(10)
+
     page_view = PageView(
         page_url="https://www.snowplow.io",
         page_title="Homepage",
-        event_subject=t.subject,
+        event_subject=event_subject,
     )
     t.track(page_view)
 

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -95,12 +95,12 @@ class Event(object):
             self.payload.add("ttm", int(self.true_timestamp))
 
         if self.event_subject is not None:
-            fin_subject = self.event_subject.combine_subject(subject)
+            fin_payload_dict = self.event_subject.combine_subject(subject)
         else:
-            fin_subject = subject
+            fin_payload_dict = None if subject is None else subject.standard_nv_pairs
 
-        if fin_subject is not None:
-            self.payload.add_dict(fin_subject.standard_nv_pairs)
+        if fin_payload_dict is not None:
+            self.payload.add_dict(fin_payload_dict)
         return self.payload
 
     @property

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -94,7 +94,7 @@ class Event(object):
         ):
             self.payload.add("ttm", int(self.true_timestamp))
 
-        fin_subject = self.event_subject if self.event_subject is not None else subject
+        fin_subject = self.event_subject.combine_subject(subject)
 
         if fin_subject is not None:
             self.payload.add_dict(fin_subject.standard_nv_pairs)

--- a/snowplow_tracker/events/event.py
+++ b/snowplow_tracker/events/event.py
@@ -94,7 +94,10 @@ class Event(object):
         ):
             self.payload.add("ttm", int(self.true_timestamp))
 
-        fin_subject = self.event_subject.combine_subject(subject)
+        if self.event_subject is not None:
+            fin_subject = self.event_subject.combine_subject(subject)
+        else:
+            fin_subject = subject
 
         if fin_subject is not None:
             self.payload.add_dict(fin_subject.standard_nv_pairs)

--- a/snowplow_tracker/subject.py
+++ b/snowplow_tracker/subject.py
@@ -179,7 +179,7 @@ class Subject(object):
         Merges another instance of Subject, with self taking priority
         :param  subject     Subject to update
         :type   subject     subject
-        :rtype              subject
+        :rtype              PayloadDict
 
         """
         if subject is not None:

--- a/snowplow_tracker/subject.py
+++ b/snowplow_tracker/subject.py
@@ -15,6 +15,7 @@
 #     language governing permissions and limitations there under.
 # """
 
+from typing import Optional
 from snowplow_tracker.contracts import one_of, greater_than
 from snowplow_tracker.typing import SupportedPlatform, SUPPORTED_PLATFORMS
 
@@ -29,7 +30,6 @@ class Subject(object):
     """
 
     def __init__(self) -> None:
-
         self.standard_nv_pairs = {"p": DEFAULT_PLATFORM}
 
     def set_platform(self, value: SupportedPlatform) -> "Subject":
@@ -172,4 +172,9 @@ class Subject(object):
         :rtype:                 subject
         """
         self.standard_nv_pairs["tnuid"] = nuid
+        return self
+
+    def combine_subject(self, subject: Optional["Subject"]) -> "Subject":
+        if subject is not None:
+            self.standard_nv_pairs.update(subject.standard_nv_pairs)
         return self

--- a/snowplow_tracker/subject.py
+++ b/snowplow_tracker/subject.py
@@ -175,6 +175,13 @@ class Subject(object):
         return self
 
     def combine_subject(self, subject: Optional["Subject"]) -> "Subject":
+        """
+        Merges another instance of Subject, with self taking priority
+        :param  subject     Subject to update
+        :type   subject     subject
+        :rtype              subject
+
+        """
         if subject is not None:
-            self.standard_nv_pairs.update(subject.standard_nv_pairs)
+            subject.standard_nv_pairs.update(self.standard_nv_pairs)
         return self

--- a/snowplow_tracker/subject.py
+++ b/snowplow_tracker/subject.py
@@ -17,7 +17,7 @@
 
 from typing import Optional
 from snowplow_tracker.contracts import one_of, greater_than
-from snowplow_tracker.typing import SupportedPlatform, SUPPORTED_PLATFORMS
+from snowplow_tracker.typing import SupportedPlatform, SUPPORTED_PLATFORMS, PayloadDict
 
 DEFAULT_PLATFORM = "pc"
 
@@ -174,7 +174,7 @@ class Subject(object):
         self.standard_nv_pairs["tnuid"] = nuid
         return self
 
-    def combine_subject(self, subject: Optional["Subject"]) -> "Subject":
+    def combine_subject(self, subject: Optional["Subject"]) -> PayloadDict:
         """
         Merges another instance of Subject, with self taking priority
         :param  subject     Subject to update
@@ -183,5 +183,6 @@ class Subject(object):
 
         """
         if subject is not None:
-            subject.standard_nv_pairs.update(self.standard_nv_pairs)
-        return self
+            return {**subject.standard_nv_pairs, **self.standard_nv_pairs}
+
+        return self.standard_nv_pairs

--- a/snowplow_tracker/test/unit/test_subject.py
+++ b/snowplow_tracker/test/unit/test_subject.py
@@ -86,3 +86,24 @@ class TestSubject(unittest.TestCase):
             s.standard_nv_pairs["vid"]
         with pytest.raises(KeyError):
             s.standard_nv_pairs["tnuid"]
+
+    def test_combine_subject(self) -> None:
+        s = _subject.Subject()
+        s.set_color_depth(10)
+        s.set_domain_session_id("domain_session_id")
+
+        s2 = _subject.Subject()
+        s.set_domain_user_id("domain_user_id")
+        s.set_lang("en")
+
+        s.combine_subject(s2)
+
+        expected_subject = {
+            "p": "pc",
+            "cd": 10,
+            "sid": "domain_session_id",
+            "duid": "domain_user_id",
+            "lang": "en",
+        }
+
+        self.assertDictEqual(s.standard_nv_pairs, expected_subject)

--- a/snowplow_tracker/test/unit/test_subject.py
+++ b/snowplow_tracker/test/unit/test_subject.py
@@ -93,12 +93,12 @@ class TestSubject(unittest.TestCase):
         s.set_domain_session_id("domain_session_id")
 
         s2 = _subject.Subject()
-        s.set_domain_user_id("domain_user_id")
-        s.set_lang("en")
+        s2.set_domain_user_id("domain_user_id")
+        s2.set_lang("en")
 
-        s.combine_subject(s2)
+        fin_payload_dict = s.combine_subject(s2)
 
-        expected_subject = {
+        expected_fin_payload_dict = {
             "p": "pc",
             "cd": 10,
             "sid": "domain_session_id",
@@ -106,4 +106,11 @@ class TestSubject(unittest.TestCase):
             "lang": "en",
         }
 
+        expected_subject = {
+            "p": "pc",
+            "cd": 10,
+            "sid": "domain_session_id",
+        }
+
+        self.assertDictEqual(fin_payload_dict, expected_fin_payload_dict)
         self.assertDictEqual(s.standard_nv_pairs, expected_subject)


### PR DESCRIPTION
This PR adds the ability to combine tracker and event subjects, with event subjects taking priority similarly to the rust tracker.