### PR TITLE
Release/1.0.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Version 1.0.1 (2023-07-12)
+--------------------------
+Fix tstamp parameter in track_self_describing_event (#350) (Thanks to @andehen)
+
 Version 1.0.0 (2023-06-16)
 --------------------------
 Remove Redis and Celery Emitters (#335)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ copyright = "2023, Alex Dean, Paul Boocock, Matus Tomlein, Jack Keene"
 author = 'Alex Dean, Paul Boocock, Matus Tomlein, Jack Keene'
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.0"
+release = "1.0.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ authors_email_str = ", ".join(authors_email_list)
 
 setup(
     name="snowplow-tracker",
-    version="1.0.0",
+    version="1.0.1",
     author=authors_str,
     author_email=authors_email_str,
     packages=["snowplow_tracker", "snowplow_tracker.test", "snowplow_tracker.events"],

--- a/snowplow_tracker/_version.py
+++ b/snowplow_tracker/_version.py
@@ -15,6 +15,6 @@
 #     language governing permissions and limitations there under.
 # """
 
-__version_info__ = (1, 0, 0)
+__version_info__ = (1, 0, 1)
 __version__ = ".".join(str(x) for x in __version_info__)
 __build_version__ = __version__ + ""

--- a/snowplow_tracker/test/unit/test_tracker.py
+++ b/snowplow_tracker/test/unit/test_tracker.py
@@ -771,7 +771,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["true_timestamp"], evTstamp)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_link_click_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -795,7 +795,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["true_timestamp"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_add_to_cart(self, mok_track_unstruct: Any) -> None:
@@ -835,7 +835,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["true_timestamp"], evTstamp)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_add_to_cart_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -857,7 +857,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["true_timestamp"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_remove_from_cart(self, mok_track_unstruct: Any) -> None:
@@ -897,7 +897,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["true_timestamp"], evTstamp)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_remove_from_cart_optional_none(
@@ -921,7 +921,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["true_timestamp"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_change(self, mok_track_unstruct: Any) -> None:
@@ -961,7 +961,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["true_timestamp"], evTstamp)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_change_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -987,7 +987,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["true_timestamp"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit(self, mok_track_unstruct: Any) -> None:
@@ -1029,7 +1029,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["true_timestamp"], evTstamp)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_invalid_element_type(
@@ -1104,7 +1104,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["true_timestamp"], evTstamp)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -1122,7 +1122,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["true_timestamp"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_form_submit_empty_elems(self, mok_track_unstruct: Any) -> None:
@@ -1170,7 +1170,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["true_timestamp"], evTstamp)
+        self.assertEqual(callArgs["tstamp"], evTstamp)
 
     @mock.patch("snowplow_tracker.Tracker.track_self_describing_event")
     def test_track_site_search_optional_none(self, mok_track_unstruct: Any) -> None:
@@ -1191,7 +1191,7 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertTrue(callArgs["context"] is None)
-        self.assertTrue(callArgs["true_timestamp"] is None)
+        self.assertTrue(callArgs["tstamp"] is None)
 
     @mock.patch("snowplow_tracker.Tracker.track")
     def test_track_mobile_screen_view(self, mok_track: Any) -> None:
@@ -1246,4 +1246,4 @@ class TestTracker(unittest.TestCase):
         self.assertEqual(len(callArgs), 4)
         self.assertDictEqual(callArgs["event_json"].to_json(), expected)
         self.assertIs(callArgs["context"][0], ctx)
-        self.assertEqual(callArgs["true_timestamp"], evTstamp)
+        self.assertEqual(callArgs["tstamp"], evTstamp)

--- a/snowplow_tracker/tracker.py
+++ b/snowplow_tracker/tracker.py
@@ -316,7 +316,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            true_timestamp=tstamp,
+            tstamp=tstamp,
             event_subject=event_subject,
         )
         return self
@@ -380,7 +380,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            true_timestamp=tstamp,
+            tstamp=tstamp,
             event_subject=event_subject,
         )
         return self
@@ -444,7 +444,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            true_timestamp=tstamp,
+            tstamp=tstamp,
             event_subject=event_subject,
         )
         return self
@@ -510,7 +510,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            true_timestamp=tstamp,
+            tstamp=tstamp,
             event_subject=event_subject,
         )
         return self
@@ -563,7 +563,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            true_timestamp=tstamp,
+            tstamp=tstamp,
             event_subject=event_subject,
         )
         return self
@@ -618,7 +618,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            true_timestamp=tstamp,
+            tstamp=tstamp,
             event_subject=event_subject,
         )
         return self
@@ -807,7 +807,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            true_timestamp=tstamp,
+            tstamp=tstamp,
             event_subject=event_subject,
         )
         return self
@@ -992,7 +992,7 @@ class Tracker:
         self.track_self_describing_event(
             event_json=event_json,
             context=context,
-            true_timestamp=tstamp,
+            tstamp=tstamp,
             event_subject=event_subject,
         )
         return self


### PR DESCRIPTION
This release fixes a small bug in the self describing event timestamp assignment.

CHANGELOG
- track_self_describing_event() is called with an unexpected keyword argument true_timestamp (#350) 