### PR TITLE
Release/1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+Version 1.0.2 (2024-02-26)
+--------------------------
+Add Python 3.12 to CI tests (#356) (Thanks to @edgarrmondragon)
+
 Version 1.0.1 (2023-07-12)
 --------------------------
 Fix tstamp parameter in track_self_describing_event (#350) (Thanks to @andehen)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN git clone --depth=1 https://github.com/pyenv/pyenv.git $PYENV_ROOT
 RUN git clone --depth=1 https://github.com/pyenv/pyenv-virtualenv.git $PYENV_ROOT/plugins/pyenv-virtualenv
 
-RUN pyenv install 3.5.10 && pyenv install 3.6.14 && pyenv install 3.7.11 && pyenv install 3.8.11 && pyenv install 3.9.6 && pyenv install 3.10.1 && pyenv install 3.11.0
+RUN pyenv install 3.5.10 && pyenv install 3.6.14 && pyenv install 3.7.11 && pyenv install 3.8.11 && pyenv install 3.9.6 && pyenv install 3.10.1 && pyenv install 3.11.0 && pyenv install 3.12.1
 
 WORKDIR /app
 COPY . .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,7 @@ copyright = "2023, Alex Dean, Paul Boocock, Matus Tomlein, Jack Keene"
 author = 'Alex Dean, Paul Boocock, Matus Tomlein, Jack Keene'
 
 # The full version, including alpha/beta/rc tags
-release = "1.0.1"
+release = "1.0.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -78,6 +78,14 @@ function deploy {
     source deactivate
   fi
 
+  # pyenv install 3.12.0
+  if [ ! -e ~/.pyenv/versions/tracker312 ]; then
+    pyenv virtualenv 3.12.0 tracker312
+    pyenv activate tracker312
+    pip install .
+    pip install -r requirements-test.txt
+    source deactivate
+  fi
 }
 
 
@@ -109,6 +117,10 @@ function run_tests {
   pyenv activate tracker311
   pytest
   source deactivate
+
+  pyenv activate tracker312
+  pytest
+  source deactivate
 }
 
 function refresh_deploy {
@@ -119,6 +131,7 @@ function refresh_deploy {
   pyenv uninstall -f tracker39
   pyenv uninstall -f tracker310
   pyenv uninstall -f tracker311
+  pyenv uninstall -f tracker312
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ authors_email_str = ", ".join(authors_email_list)
 
 setup(
     name="snowplow-tracker",
-    version="1.0.1",
+    version="1.0.2",
     author=authors_str,
     author_email=authors_email_str,
     packages=["snowplow_tracker", "snowplow_tracker.test", "snowplow_tracker.events"],

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Operating System :: OS Independent",
     ],
     install_requires=["requests>=2.25.1,<3.0", "typing_extensions>=3.7.4"],

--- a/snowplow_tracker/_version.py
+++ b/snowplow_tracker/_version.py
@@ -15,6 +15,6 @@
 #     language governing permissions and limitations there under.
 # """
 
-__version_info__ = (1, 0, 1)
+__version_info__ = (1, 0, 2)
 __version__ = ".".join(str(x) for x in __version_info__)
 __build_version__ = __version__ + ""


### PR DESCRIPTION
This PR adds support for Python 3.12.

CHANGELOG
- Add Python 3.12 to CI tests ([#356 ](https://github.com/snowplow/snowplow-python-tracker/issues/356))