### PR TITLE
Add py.typed to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
     author=authors_str,
     author_email=authors_email_str,
     packages=["snowplow_tracker", "snowplow_tracker.test", "snowplow_tracker.events"],
+    package_data={"snowplow_tracker": ["py.typed"]},
     url="http://snowplow.io",
     license="Apache License 2.0",
     description="Snowplow event tracker for Python. Add analytics to your Python and Django apps, webapps and games",


### PR DESCRIPTION
Followed the official guide[^1] and confirmed it's included in the artifacts when building with `python setup.py sdist bdist_wheel`:

```console
$ tree dist/snowplow_tracker-1.0.2 -P py.typed  # sdist
dist/snowplow_tracker-1.0.2
├── docs
├── snowplow_tracker
│   ├── events
│   ├── py.typed
│   └── test
└── snowplow_tracker.egg-info

$ tree dist/snowplow_tracker-1.0.2-py3-none-any -P py.typed  # wheel
dist/snowplow_tracker-1.0.2-py3-none-any
├── snowplow_tracker
│   ├── events
│   ├── py.typed
│   └── test
└── snowplow_tracker-1.0.2.dist-info
```

Closes https://github.com/snowplow/snowplow-python-tracker/issues/360

[^1]: https://typing.readthedocs.io/en/latest/guides/libraries.html#marking-a-package-as-providing-type-information