### PR TITLE
Fix `PagePing`, `PageView`, and `StructuredEvent` property getters

### DIFF
--- a/snowplow_tracker/events/page_ping.py
+++ b/snowplow_tracker/events/page_ping.py
@@ -81,7 +81,7 @@ class PagePing(Event):
         """
         URL of the viewed page
         """
-        return self.payload.get("url")
+        return self.payload.nv_pairs["url"]
 
     @page_url.setter
     def page_url(self, value: str):
@@ -93,7 +93,7 @@ class PagePing(Event):
         """
         URL of the viewed page
         """
-        return self.payload.get("page")
+        return self.payload.nv_pairs.get("page")
 
     @page_title.setter
     def page_title(self, value: Optional[str]):
@@ -104,7 +104,7 @@ class PagePing(Event):
         """
         The referrer of the page
         """
-        return self.payload.get("refr")
+        return self.payload.nv_pairs.get("refr")
 
     @referrer.setter
     def referrer(self, value: Optional[str]):
@@ -115,7 +115,7 @@ class PagePing(Event):
         """
         Minimum page x offset seen in the last ping period
         """
-        return self.payload.get("pp_mix")
+        return self.payload.nv_pairs.get("pp_mix")
 
     @min_x.setter
     def min_x(self, value: Optional[int]):
@@ -126,7 +126,7 @@ class PagePing(Event):
         """
         Maximum page x offset seen in the last ping period
         """
-        return self.payload.get("pp_max")
+        return self.payload.nv_pairs.get("pp_max")
 
     @max_x.setter
     def max_x(self, value: Optional[int]):
@@ -137,7 +137,7 @@ class PagePing(Event):
         """
         Minimum page y offset seen in the last ping period
         """
-        return self.payload.get("pp_miy")
+        return self.payload.nv_pairs.get("pp_miy")
 
     @min_y.setter
     def min_y(self, value: Optional[int]):
@@ -148,7 +148,7 @@ class PagePing(Event):
         """
         Maximum page y offset seen in the last ping period
         """
-        return self.payload.get("pp_may")
+        return self.payload.nv_pairs.get("pp_may")
 
     @max_y.setter
     def max_y(self, value: Optional[int]):

--- a/snowplow_tracker/events/page_view.py
+++ b/snowplow_tracker/events/page_view.py
@@ -65,7 +65,7 @@ class PageView(Event):
         """
         URL of the viewed page
         """
-        return self.payload.get("url")
+        return self.payload.nv_pairs["url"]
 
     @page_url.setter
     def page_url(self, value: str):
@@ -77,7 +77,7 @@ class PageView(Event):
         """
         Title of the viewed page
         """
-        return self.payload.get("page")
+        return self.payload.nv_pairs.get("page")
 
     @page_title.setter
     def page_title(self, value: Optional[str]):
@@ -88,7 +88,7 @@ class PageView(Event):
         """
         The referrer of the page
         """
-        return self.payload.get("refr")
+        return self.payload.nv_pairs.get("refr")
 
     @referrer.setter
     def referrer(self, value: Optional[str]):

--- a/snowplow_tracker/events/structured_event.py
+++ b/snowplow_tracker/events/structured_event.py
@@ -81,7 +81,7 @@ class StructuredEvent(Event):
         """
         Category of the event
         """
-        return self.payload.get("se_ca")
+        return self.payload.nv_pairs.get("se_ca")
 
     @category.setter
     def category(self, value: Optional[str]):
@@ -93,7 +93,7 @@ class StructuredEvent(Event):
         """
         The event itself
         """
-        return self.payload.get("se_ac")
+        return self.payload.nv_pairs.get("se_ac")
 
     @action.setter
     def action(self, value: Optional[str]):
@@ -105,7 +105,7 @@ class StructuredEvent(Event):
         """
         Refer to the object the action is performed on
         """
-        return self.payload.get("se_la")
+        return self.payload.nv_pairs.get("se_la")
 
     @label.setter
     def label(self, value: Optional[str]):
@@ -116,7 +116,7 @@ class StructuredEvent(Event):
         """
         Property associated with either the action or the object
         """
-        return self.payload.get("se_pr")
+        return self.payload.nv_pairs.get("se_pr")
 
     @property_.setter
     def property_(self, value: Optional[str]):
@@ -127,7 +127,7 @@ class StructuredEvent(Event):
         """
         A value associated with the user action
         """
-        return self.payload.get("se_va")
+        return self.payload.nv_pairs.get("se_va")
 
     @value.setter
     def value(self, value: Optional[int]):

--- a/snowplow_tracker/test/unit/test_page_ping.py
+++ b/snowplow_tracker/test/unit/test_page_ping.py
@@ -1,0 +1,38 @@
+import pytest
+
+from snowplow_tracker.events.page_ping import PagePing
+
+
+class TestPagePing:
+    def test_getters(self):
+        pp = PagePing("url", "title", "referrer", 1, 2, 3, 4)
+        assert pp.page_url == "url"
+        assert pp.page_title == "title"
+        assert pp.referrer == "referrer"
+        assert pp.min_x == 1
+        assert pp.max_x == 2
+        assert pp.min_y == 3
+        assert pp.max_y == 4
+
+    def test_setters(self):
+        pp = PagePing("url")
+        pp.page_title = "title"
+        pp.referrer = "referrer"
+        pp.min_x = 1
+        pp.max_x = 2
+        pp.min_y = 3
+        pp.max_y = 4
+        assert pp.page_title == "title"
+        assert pp.referrer == "referrer"
+        assert pp.min_x == 1
+        assert pp.max_x == 2
+        assert pp.min_y == 3
+        assert pp.max_y == 4
+        assert pp.page_url == "url"
+
+    def test_page_url_non_empty_string(self):
+        pp = PagePing("url")
+        pp.page_url = "new_url"
+        assert pp.page_url == "new_url"
+        with pytest.raises(ValueError):
+            pp.page_url = ""

--- a/snowplow_tracker/test/unit/test_page_view.py
+++ b/snowplow_tracker/test/unit/test_page_view.py
@@ -1,0 +1,27 @@
+import pytest
+
+from snowplow_tracker.events.page_view import PageView
+
+
+class TestPageView:
+    def test_getters(self):
+        pv = PageView("url", "title", "referrer")
+        assert pv.page_url == "url"
+        assert pv.page_title == "title"
+        assert pv.referrer == "referrer"
+
+    def test_setters(self):
+        pv = PageView("url", "title", "referrer")
+        pv.page_url = "new_url"
+        pv.page_title = "new_title"
+        pv.referrer = "new_referrer"
+        assert pv.page_url == "new_url"
+        assert pv.page_title == "new_title"
+        assert pv.referrer == "new_referrer"
+
+    def test_page_url_non_empty_string(self):
+        pv = PageView("url")
+        pv.page_url = "new_url"
+        assert pv.page_url == "new_url"
+        with pytest.raises(ValueError):
+            pv.page_url = ""

--- a/snowplow_tracker/test/unit/test_structured_event.py
+++ b/snowplow_tracker/test/unit/test_structured_event.py
@@ -1,0 +1,24 @@
+from snowplow_tracker.events.structured_event import StructuredEvent
+
+
+class TestStructuredEvent:
+    def test_getters(self):
+        se = StructuredEvent("category", "action", "label", "property", 1)
+        assert se.category == "category"
+        assert se.action == "action"
+        assert se.label == "label"
+        assert se.property_ == "property"
+        assert se.value == 1
+
+    def test_setters(self):
+        se = StructuredEvent("category", "action")
+        se.category = "new_category"
+        se.action = "new_action"
+        se.label = "new_label"
+        se.property_ = "new_property"
+        se.value = 2
+        assert se.category == "new_category"
+        assert se.action == "new_action"
+        assert se.label == "new_label"
+        assert se.property_ == "new_property"
+        assert se.value == 2


### PR DESCRIPTION
This PR fixes the property getters in `PagePing`, `PageView` and `StructuredEvent`. They were previously attempting to access the `.get` method of `Payload`, which didn't take an argument, causing the tracker to throw an error.

They now access `nv_pairs` with `.get` when the return type is optional, or with indexing when non-optional. 