### PR TITLE
Avoid installing `types-requests` at run-time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: MyPy
       run: |
-        python -m pip install mypy
+        python -m pip install -e .[typing]
         mypy snowplow_tracker --exclude '/test'
       
     - name: Demo

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,12 @@ setup(
     ],
     install_requires=[
         "requests>=2.25.1,<3.0",
-        "types-requests>=2.25.1,<3.0",
         "typing_extensions>=3.7.4",
     ],
+    extras_require={
+        "typing": [
+            "mypy>=0.971",
+            "types-requests>=2.25.1,<3.0",
+        ],
+    },
 )


### PR DESCRIPTION
It's not required, so you could simply make it a dev dependency.